### PR TITLE
Add Command to run test classes

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var commands = []*Command{
 	cmdImport,
 	cmdQuery,
 	cmdApex,
+	cmdTest,
 	/* cmdOauth,*/
 	cmdVersion,
 	cmdUpdate,

--- a/partner.go
+++ b/partner.go
@@ -13,12 +13,9 @@ type ForcePartner struct {
 
 type TestCoverage struct {
 		Log 							string `xml:"Header>DebuggingInfo>debugLog"`
-		NumberRun 						string `xml:"Body>runTestsResponse>result>numTestsRun"`
 		NumberLocations 				[]int `xml:"Body>runTestsResponse>result>codeCoverage>numLocations"`
 		NumberLocationsNotCovered		[]int `xml:"Body>runTestsResponse>result>codeCoverage>numLocationsNotCovered"`
-		Type 							[]string `xml:"Body>runTestsResponse>result>codeCoverage>type"`
 		Name 							[]string `xml:"Body>runTestsResponse>result>codeCoverage>name"`
-		Id 								[]string `xml:Body>runTestsResponse>result>codeCoverage>id"`
 		SMethodNames 					[]string `xml:"Body>runTestsResponse>result>successes>methodName"`
 		SClassNames						[]string `xml:"Body>runTestsResponse>result>successes>name"`
 		FMethodNames 					[]string `xml:"Body>runTestsResponse>result>failures>methodName"`

--- a/partner.go
+++ b/partner.go
@@ -12,14 +12,15 @@ type ForcePartner struct {
 }
 
 type TestCoverage struct {
-		Log 							string `xml:"Header>DebuggingInfo>debugLog"`
-		NumberLocations 				[]int `xml:"Body>runTestsResponse>result>codeCoverage>numLocations"`
-		NumberLocationsNotCovered		[]int `xml:"Body>runTestsResponse>result>codeCoverage>numLocationsNotCovered"`
-		Name 							[]string `xml:"Body>runTestsResponse>result>codeCoverage>name"`
-		SMethodNames 					[]string `xml:"Body>runTestsResponse>result>successes>methodName"`
-		SClassNames						[]string `xml:"Body>runTestsResponse>result>successes>name"`
-		FMethodNames 					[]string `xml:"Body>runTestsResponse>result>failures>methodName"`
-		FClassNames						[]string `xml:"Body>runTestsResponse>result>failures>name"`
+	Log                       string   `xml:"Header>DebuggingInfo>debugLog"`
+	NumberRun                 int      `xml:"Body>runTestsResponse>result>numTestsRun"`
+	NumberLocations           []int    `xml:"Body>runTestsResponse>result>codeCoverage>numLocations"`
+	NumberLocationsNotCovered []int    `xml:"Body>runTestsResponse>result>codeCoverage>numLocationsNotCovered"`
+	Name                      []string `xml:"Body>runTestsResponse>result>codeCoverage>name"`
+	SMethodNames              []string `xml:"Body>runTestsResponse>result>successes>methodName"`
+	SClassNames               []string `xml:"Body>runTestsResponse>result>successes>name"`
+	FMethodNames              []string `xml:"Body>runTestsResponse>result>failures>methodName"`
+	FClassNames               []string `xml:"Body>runTestsResponse>result>failures>name"`
 }
 
 func NewForcePartner(force *Force) (partner *ForcePartner) {
@@ -76,26 +77,26 @@ func (partner *ForcePartner) ExecuteAnonymous(apex string) (output string, err e
 }
 
 func (partner *ForcePartner) RunTests(tests string) (output TestCoverage, err error) {
-	test_names := strings.Split(tests," ")
+	test_names := strings.Split(tests, " ")
 	soap := "<RunTestsRequest>\n"
-	if test_names[0] == "all" || test_names[0] == "All" {
-		soap+="<allTests>True</allTests>\n"
-	}else{
-		for _,element := range test_names {
-			soap+="<classes>" + element + "</classes>\n"
+	if strings.EqualFold(test_names[0], "all") {
+		soap += "<allTests>True</allTests>\n"
+	} else {
+		for _, element := range test_names {
+			soap += "<classes>" + element + "</classes>\n"
 		}
 	}
-	soap+="</RunTestsRequest>"
+	soap += "</RunTestsRequest>"
 	body, err := partner.soapExecute("runTests", soap)
 	if err != nil {
-		return 
+		return
 	}
 	var result TestCoverage
 	if err = xml.Unmarshal(body, &result); err != nil {
-		return 
+		return
 	}
 	output = result
-	return 
+	return
 }
 
 func (partner *ForcePartner) soapExecute(action, query string) (response []byte, err error) {

--- a/partner.go
+++ b/partner.go
@@ -11,6 +11,20 @@ type ForcePartner struct {
 	Force *Force
 }
 
+type TestCoverage struct {
+		Log 							string `xml:"Header>DebuggingInfo>debugLog"`
+		NumberRun 						string `xml:"Body>runTestsResponse>result>numTestsRun"`
+		NumberLocations 				[]int `xml:"Body>runTestsResponse>result>codeCoverage>numLocations"`
+		NumberLocationsNotCovered		[]int `xml:"Body>runTestsResponse>result>codeCoverage>numLocationsNotCovered"`
+		Type 							[]string `xml:"Body>runTestsResponse>result>codeCoverage>type"`
+		Name 							[]string `xml:"Body>runTestsResponse>result>codeCoverage>name"`
+		Id 								[]string `xml:Body>runTestsResponse>result>codeCoverage>id"`
+		SMethodNames 					[]string `xml:"Body>runTestsResponse>result>successes>methodName"`
+		SClassNames						[]string `xml:"Body>runTestsResponse>result>successes>name"`
+		FMethodNames 					[]string `xml:"Body>runTestsResponse>result>failures>methodName"`
+		FClassNames						[]string `xml:"Body>runTestsResponse>result>failures>name"`
+}
+
 func NewForcePartner(force *Force) (partner *ForcePartner) {
 	partner = &ForcePartner{Force: force}
 	return
@@ -62,6 +76,29 @@ func (partner *ForcePartner) ExecuteAnonymous(apex string) (output string, err e
 	}
 	output = result.Log
 	return
+}
+
+func (partner *ForcePartner) RunTests(tests string) (output TestCoverage, err error) {
+	test_names := strings.Split(tests," ")
+	soap := "<RunTestsRequest>\n"
+	if test_names[0] == "all" || test_names[0] == "All" {
+		soap+="<allTests>True</allTests>\n"
+	}else{
+		for _,element := range test_names {
+			soap+="<classes>" + element + "</classes>\n"
+		}
+	}
+	soap+="</RunTestsRequest>"
+	body, err := partner.soapExecute("runTests", soap)
+	if err != nil {
+		return 
+	}
+	var result TestCoverage
+	if err = xml.Unmarshal(body, &result); err != nil {
+		return 
+	}
+	output = result
+	return 
 }
 
 func (partner *ForcePartner) soapExecute(action, query string) (response []byte, err error) {

--- a/tests.go
+++ b/tests.go
@@ -30,9 +30,9 @@ func runTests(cmd *Command, args []string) {
 		ErrorAndExit(err.Error())
 	} else {
 		//working on a better way to do this - catches when no class are found and ran
-		if output.NumberRun == "0" {
+		if output.NumberRun == 0 {
 			println("test classes specified not found")
-		}else{
+		} else {
 			var percent string
 			println(output.Log)
 			println()
@@ -45,7 +45,7 @@ func runTests(cmd *Command, args []string) {
 					percent = strconv.Itoa(((output.NumberLocations[index]-output.NumberLocationsNotCovered[index])/output.NumberLocations[index])*100) + "%"
 				} else {
 					percent = "0%"
-				} 
+				}
 				println(percent + "   " + output.Name[index])
 			}
 			println()
@@ -53,11 +53,11 @@ func runTests(cmd *Command, args []string) {
 			println("Results:")
 			println()
 			//println()
-			for index := range output.SMethodNames{
+			for index := range output.SMethodNames {
 				println("[PASS]    " + output.SClassNames[index] + "::" + output.SMethodNames[index])
 			}
 
-			for index := range output.FMethodNames{
+			for index := range output.FMethodNames {
 				println("[FAIL]    " + output.FClassNames[index] + "::" + output.FMethodNames[index])
 			}
 			println()

--- a/tests.go
+++ b/tests.go
@@ -33,44 +33,35 @@ func runTests(cmd *Command, args []string) {
 		if output.NumberRun == "0" {
 			println("test classes specified not found")
 		}else{
-			println("NumberRun: " + output.NumberRun)
-			println()
+			var percent string
 			println(output.Log)
 			println()
-			println("****Test Coverage****")
-			println("__________________________________")
-			var percent string
-			var locs_covered, locs_not int
+			println()
+			println("Coverage:")
+			println()
+			//println()
 			for index := range output.NumberLocations {
 				if output.NumberLocations[index] != 0 {
 					percent = strconv.Itoa(((output.NumberLocations[index]-output.NumberLocationsNotCovered[index])/output.NumberLocations[index])*100) + "%"
-					locs_covered += output.NumberLocations[index]
-					locs_not += output.NumberLocationsNotCovered[index]
 				} else {
 					percent = "0%"
 				} 
-				println(output.Name[index] + "  " + output.Type[index] + "  " + percent)
+				println(percent + "   " + output.Name[index])
 			}
-			println("__________________________________")
-			println("Total" + "  " + strconv.Itoa(((locs_covered-locs_not)/locs_covered)*100) + "%")
-			
 			println()
 			println()
-
-			println("****SUCCESSES****")
-			println("__________________________________")
+			println("Results:")
+			println()
+			//println()
 			for index := range output.SMethodNames{
-				println(output.SClassNames[index] + "    " + output.SMethodNames[index])
+				println("[PASS]    " + output.SClassNames[index] + "::" + output.SMethodNames[index])
 			}
 
-			println()
-			println()
-
-			println("****FAILURES****")
-			println("__________________________________")
 			for index := range output.FMethodNames{
-				println(output.FClassNames[index] + "    " + output.FMethodNames[index])
+				println("[FAIL]    " + output.FClassNames[index] + "::" + output.FMethodNames[index])
 			}
+			println()
+			println()
 		}
 	}
 }

--- a/tests.go
+++ b/tests.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+var cmdTest = &Command{
+	Run:   runTests,
+	Usage: "tests",
+	Short: "Run apex tests",
+	Long: `
+Execute apex tests 
+
+Examples:
+
+  force tests Test1 Test2 Test3
+  force tests all 
+`,
+}
+
+func runTests(cmd *Command, args []string) {
+	if len(args) < 1 {
+		ErrorAndExit("must specify tests to run")
+	}
+	tests := strings.Join(args, " ")
+	force, _ := ActiveForce()
+	output, err := force.Partner.RunTests(tests)
+	if err != nil {
+		ErrorAndExit(err.Error())
+	} else {
+		//working on a better way to do this - catches when no class are found and ran
+		if output.NumberRun == "0" {
+			println("test classes specified not found")
+		}else{
+			println("NumberRun: " + output.NumberRun)
+			println()
+			println(output.Log)
+			println()
+			println("****Test Coverage****")
+			println("__________________________________")
+			var percent string
+			var locs_covered, locs_not int
+			for index := range output.NumberLocations {
+				if output.NumberLocations[index] != 0 {
+					percent = strconv.Itoa(((output.NumberLocations[index]-output.NumberLocationsNotCovered[index])/output.NumberLocations[index])*100) + "%"
+					locs_covered += output.NumberLocations[index]
+					locs_not += output.NumberLocationsNotCovered[index]
+				} else {
+					percent = "0%"
+				} 
+				println(output.Name[index] + "  " + output.Type[index] + "  " + percent)
+			}
+			println("__________________________________")
+			println("Total" + "  " + strconv.Itoa(((locs_covered-locs_not)/locs_covered)*100) + "%")
+			
+			println()
+			println()
+
+			println("****SUCCESSES****")
+			println("__________________________________")
+			for index := range output.SMethodNames{
+				println(output.SClassNames[index] + "    " + output.SMethodNames[index])
+			}
+
+			println()
+			println()
+
+			println("****FAILURES****")
+			println("__________________________________")
+			for index := range output.FMethodNames{
+				println(output.FClassNames[index] + "    " + output.FMethodNames[index])
+			}
+		}
+	}
+}


### PR DESCRIPTION
New command force tests, runs apex test classes using the RunTestsRequests call. Ability to specify classes to run or specify to run all. Returns number run, debug log, the coverage, the successes and the failures.

The new files tests.go is the command, and I added the callout and xml creation to the partner.go file. This was my first time using Go, so I was researching as I wrote this. If I could have done something more efficiently, I'd really like to know. The format of the output is below for the force tests all command.

NumberRun: 3

29.0 APEX_CODE,DEBUG;APEX_PROFILING,INFO

15:12:08.091|CUMULATIVE_LIMIT_USAGE_END

15:12:08.117 (117811000)|CODE_UNIT_FINISHED|testNumbers.testMakeNumbers2
15:12:08.117 (117819000)|EXECUTION_FINISHED

****Test Coverage****

DoStuff Class 100%
SampleClass Class 100%

Total 100%

****SUCCESSES****

testClass doTest
testNumbers testMakeNumbers

****FAILURES****

testNumbers testMakeNumbers2