### PR TITLE
Ability to set specific log levels and store debug header as file

### DIFF
--- a/loglevels.go
+++ b/loglevels.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"strings"
+	"os"
+)
+
+var cmdLogLevels = &Command{
+	Run:   runLogLevels,
+	Usage: "loglevels",
+	Short: "change debug log levels",
+	Long: ` 
+	Change Log levels for execute anonymous and running tests
+
+	Examples:
+		force loglevels show => show the current log levels 
+		force loglevels ALL:INFO => set all categories to info
+		force loglevels APEX_CODE:ERROR APEX_PROFILING:INFO => set each category specifically 
+	`,
+}
+
+type DebugOptions struct {
+	Category string `xml:"category"`
+	Level    string `xml:"level"`
+}
+
+type DebuggingHeader struct {
+	XMLName    xml.Name       `xml:"DebuggingHeader"`
+	Categories []DebugOptions `xml:"categories"`
+}
+
+func runLogLevels(cmd *Command, args []string) {
+	//first check if the debugHeader.xml exists and if not create it regardless, so it's there in the future 
+	if _, err := os.Stat("debugHeader.xml"); os.IsNotExist(err) {
+			def := "<apex:DebuggingHeader><apex:categories><apex:category>ALL</apex:category><apex:level>INFO</apex:level></apex:categories></apex:DebuggingHeader>"
+    		res := []byte(def)
+    		ioutil.WriteFile("debugHeader.xml", res, 0755)
+	}
+	if len(args) < 1 {
+		ErrorAndExit("Must specify options")
+	}else if strings.ToUpper(args[0]) == "SHOW" {
+		debug_header := &DebuggingHeader{}
+		file, _ := ioutil.ReadFile("debugHeader.xml")
+		if err := xml.Unmarshal([]byte(file), debug_header); err != nil {
+			ErrorAndExit("Error reading debug file")
+		}
+		for _,element := range debug_header.Categories {
+			println(element.Category + ":" + element.Level)
+		}
+	}else{
+		categories_available := map[string]bool{
+			"ALL":            true,
+			"WORKFLOW":       true,
+			"VALIDATION":     true,
+			"CALLOUT":        true,
+			"APEX_CODE":      true,
+			"APEX_PROFILING": true,
+		}
+
+		levels_available := map[string]bool{
+			"ERROR":  true,
+			"WARN":   true,
+			"INFO":   true,
+			"DEBUG":  true,
+			"FINE":   true,
+			"FINER":  true,
+			"FINEST": true,
+		}
+		debug_header := &DebuggingHeader{}
+		var all_val, soap string
+		file, _ := ioutil.ReadFile("debugHeader.xml")
+		if err := xml.Unmarshal([]byte(file), debug_header); err != nil {
+			return
+		}
+		new_opts := make(map[string]string)
+		for _, element := range args {
+			opt_pairs := strings.Split(string(element), ":")
+			if strings.ToUpper(opt_pairs[0]) == "ALL" {
+				all_val = strings.ToUpper(opt_pairs[1])
+				break
+			} else {
+				new_opts[strings.ToUpper(opt_pairs[0])] = strings.ToUpper(opt_pairs[1])
+			}
+		}
+		if all_val != "" {
+			soap = "<apex:DebuggingHeader><apex:categories><apex:category>ALL</apex:category><apex:level>" + all_val + "</apex:level></apex:categories></apex:DebuggingHeader>"
+		} else {
+			for index, _ := range debug_header.Categories {
+				if debug_header.Categories[index].Category == "ALL" {
+					//debug_header.Categories[index] = nil
+					debug_header.Categories = debug_header.Categories[:index+copy(debug_header.Categories[index:], debug_header.Categories[index+1:])]
+					continue
+				}
+				level, ex := new_opts[debug_header.Categories[index].Category]
+				_, cat_valid := categories_available[debug_header.Categories[index].Category]
+				_, lvl_valid := levels_available[debug_header.Categories[index].Level]
+				if ex && cat_valid && lvl_valid {
+					debug_header.Categories[index].Level = level
+					delete(new_opts, string(debug_header.Categories[index].Category))
+				}
+			}
+			if len(new_opts) != 0 {
+				for key, _ := range new_opts {
+					debug_header.Categories = append(debug_header.Categories, DebugOptions{Category: key, Level: new_opts[key]})
+				}
+			}
+			//Constructing xml this way because go doesn't currently support marshaling xml with namespace using colon
+			soap = "<apex:DebuggingHeader>"
+			for _, element := range debug_header.Categories {
+				soap += "<apex:categories><apex:category>" + element.Category + "</apex:category><apex:level>" + element.Level + "</apex:level></apex:categories>"
+			}
+			soap += "</apex:DebuggingHeader>"
+		}
+		res := []byte(soap)
+		ioutil.WriteFile("debugHeader.xml", res, 0755)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var commands = []*Command{
 	cmdImport,
 	cmdQuery,
 	cmdApex,
+	cmdLogLevels,
 	/* cmdOauth,*/
 	cmdVersion,
 	cmdUpdate,

--- a/partner.go
+++ b/partner.go
@@ -72,7 +72,9 @@ func (partner *ForcePartner) soapExecute(action, query string) (response []byte,
 	url := strings.Replace(login["urls"].(map[string]interface{})["partner"].(string), "{version}", "28.0", 1)
 	url = strings.Replace(url, "/u/", "/s/", 1) // seems dirty
 	soap := NewSoap(url, "http://soap.sforce.com/2006/08/apex", partner.Force.Credentials.AccessToken)
-	soap.Header = "<apex:DebuggingHeader><apex:debugLevel>DEBUGONLY</apex:debugLevel></apex:DebuggingHeader>"
+	file, _ := ioutil.ReadFile("debugHeader.xml")
+	soap.Header = string(file[:])
 	response, err = soap.Execute(action, query)
+	fmt.Println(string(response[:]))
 	return
 }


### PR DESCRIPTION
New command that allows user to set the debug category and level per http://www.salesforce.com/us/developer/docs/apexcode/Content/sforce_api_header_debuggingheader.htm

Stores the debug header as an external xml file so settings are saved. Allows specifying of ALL or specific categories and levels, and command to show current settings. soapExecute in partner.go updated to read the header from file, for both apex execute and future run tests call. Handles case, handles the xml file not yet existing. 

This is a proof of concept, I have some outstanding questions to discuss, including structure, where to store the header.xml file and probably more. 

Examples: 

force loglevels ALL:INFO
force loglevels APEX_CODE:ERROR APEX_PROFILING:INFO WORKFLOW:FINEST
force loglevels show 
APEX_CODE:ERROR
APEX_PROFILING:INFO
WORKFLOW:FINEST


