### PR TITLE
Limits

### DIFF
--- a/active.go
+++ b/active.go
@@ -3,9 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"os/exec"
 	"runtime"
+	"sort"
 )
 
 var cmdActive = &Command{

--- a/force.go
+++ b/force.go
@@ -200,7 +200,7 @@ type ForceCreateRecordResult struct {
 type ForceLimits map[string]ForceLimit
 
 type ForceLimit struct {
-	Name string
+	Name      string
 	Remaining int64
 	Max       int64
 }

--- a/force.go
+++ b/force.go
@@ -197,6 +197,14 @@ type ForceCreateRecordResult struct {
 	Success bool
 }
 
+type ForceLimits map[string]ForceLimit
+
+type ForceLimit struct {
+	Name string
+	Remaining int64
+	Max       int64
+}
+
 type ForcePasswordStatusResult struct {
 	IsExpired bool
 }
@@ -553,6 +561,18 @@ func (f *Force) Get(url string) (object ForceRecord, err error) {
 	}
 	err = json.Unmarshal(body, &object)
 	return
+}
+
+func (f *Force) GetLimits() (result map[string]ForceLimit, err error) {
+
+	url := fmt.Sprintf("%s/services/data/%s/limits", f.Credentials.InstanceUrl, apiVersion)
+	body, err := f.httpGet(url)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal([]byte(body), &result)
+	return
+
 }
 
 func (f *Force) GetPasswordStatus(id string) (result ForcePasswordStatusResult, err error) {

--- a/limits.go
+++ b/limits.go
@@ -24,23 +24,22 @@ func runLimits(cmd *Command, args []string) {
 
 	force, _ := ActiveForce()
 
-		var result ForceLimits
-		result, err := force.GetLimits()
+	var result ForceLimits
+	result, err := force.GetLimits()
 
-		if err != nil {
-			ErrorAndExit(err.Error())
-		} else {
-			printLimits(result)
-		}
+	if err != nil {
+		ErrorAndExit(err.Error())
+	} else {
+		printLimits(result)
+	}
 }
 
-
-func printLimits(result map[string]ForceLimit)() {
+func printLimits(result map[string]ForceLimit) {
 
 	//sort keys
 	var keys []string
 	for k := range result {
-			keys = append(keys, k)
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 

--- a/limits.go
+++ b/limits.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+var cmdLimits = &Command{
+	Usage: "limits",
+	Short: "Display current limits",
+	Long: `
+	Use the limits command to display limits information for your organization.
+
+	 -- Max is the limit total for the organization.
+
+	 -- Remaining is the total number of calls or events left for the organization.`,
+}
+
+func init() {
+	cmdLimits.Run = runLimits
+}
+
+func runLimits(cmd *Command, args []string) {
+
+	force, _ := ActiveForce()
+
+		var result ForceLimits
+		result, err := force.GetLimits()
+
+		if err != nil {
+			ErrorAndExit(err.Error())
+		} else {
+			printLimits(result)
+		}
+}
+
+
+func printLimits(result map[string]ForceLimit)() {
+
+	//sort keys
+	var keys []string
+	for k := range result {
+			keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	//print map
+	for _, k := range keys {
+		fmt.Println(k, "\n", result[k].Max, "maximum\n", result[k].Remaining, "remaining\n")
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var commands = []*Command{
 	cmdAura,
 	cmdPassword,
 	cmdNotifySet,
+	cmdLimits,
 }
 
 func main() {


### PR DESCRIPTION
I got burned by the SingleEmail limit recently, and then channeled my fury into a truly amazing 26th command option for the Force CLI.
				
It's pretty straightforward - just retrieves the latest counts from the REST API and then displays the limits, sorted alphabetically.				
				 
Example REST response:
https://www.salesforce.com/us/developer/docs/api_rest/Content/dome_limits.htm

![cli-limits-1](https://cloud.githubusercontent.com/assets/2042398/6746449/93c9cdc2-ce85-11e4-8855-fc6418d4b9d7.png)

![cli-limits-2](https://cloud.githubusercontent.com/assets/2042398/6746448/93c8f23a-ce85-11e4-8459-3b09cffcd7e7.png)
