### PR TITLE
Allow logging in using SOAP without echoing password

### DIFF
--- a/login.go
+++ b/login.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/bgentry/speakeasy"
 	"net/url"
 )
 
@@ -71,7 +72,14 @@ func runLogin(cmd *Command, args []string) {
 		}
 	}
 
-	if len(*userName) != 0 && len(*password) != 0 { // Do SOAP login
+	if len(*userName) != 0 { // Do SOAP login
+		if len(*password) == 0 {
+			var err error
+			*password, err = speakeasy.Ask("Password: ")
+			if err != nil {
+				ErrorAndExit(err.Error())
+			}
+		}
 		_, err := ForceLoginAndSaveSoap(endpoint, *userName, *password)
 		if err != nil {
 			ErrorAndExit(err.Error())


### PR DESCRIPTION
Some environments do not have access to a browser with JavaScript
enabled (such as SSH server with w3m). For these environments, one would
need to use a SOAP login. There should be a way to log in without having
to write the password in the command line history.

This patch uses a cross platform package to prevent echoing the password
if a user provides a username.