### PR TITLE
Fix Zip File Creation on Windows

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -1050,7 +1050,7 @@ func (fm *ForceMetadata) MakeZip(files ForceMetadataFiles) (zipdata []byte, err 
 	zipper := zip.NewWriter(zipfile)
 	for name, data := range files {
 		name = filepath.ToSlash(name)
-		wr, err := zipper.Create(fmt.Sprintf("unpackaged%s%s", string(os.PathSeparator), name))
+		wr, err := zipper.Create(fmt.Sprintf("unpackaged/%s", name))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Use forward slash for paths to files added to the zip file being
deployed.  Per the archive/zip documentation, Writer.Create only allows
forward slashes.

Fixes "No package.xml found" error when using `force push` on windows.