### PR TITLE
Bugfix for `force bulk query retrieve` to parse resultIds

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -174,11 +174,11 @@ func retrieveBulkQuery(jobId string, batchId string) (resultIds []string) {
 	}
 
 	var resultList struct {
-		results []string `xml:"result"`
+		Results []string `xml:"result"`
 	}
 
 	xml.Unmarshal(jobInfo, &resultList)
-	resultIds = resultList.results
+	resultIds = resultList.Results
 	return
 }
 


### PR DESCRIPTION
My prior commit (which was merged in #173) had a variable naming convention change which apparently wasn't re-compiled when I re-tested locally, therefore introducing a bug. It turns out the version I have been running locally was a prior compilation that didn't include the bug, so it went unnoticed by me. 

Extremely sorry for introducing the bug, but this commit fixes that issue, therefore allowing `force bulk query retrieve` to work.

See comment in https://github.com/heroku/force/pull/173 & http://salesforce.stackexchange.com/questions/82772/force-com-cli-bulk-query-returns-nothing