### PR TITLE
Add Trace Command

### DIFF
--- a/display.go
+++ b/display.go
@@ -173,6 +173,9 @@ func DisplayForceRecordsf(records []ForceRecord, format string) {
 	case "json":
 		recs, _ := json.Marshal(records)
 		fmt.Println(string(recs))
+	case "json-pretty":
+		recs, _ := json.MarshalIndent(records, "", "  ")
+		fmt.Println(string(recs))
 	default:
 		fmt.Printf("Format %s not supported\n\n", format)
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var commands = []*Command{
 	cmdExport,
 	cmdQuery,
 	cmdApex,
+	cmdTrace,
 	cmdLog,
 	cmdOauth,
 	cmdTest,

--- a/trace.go
+++ b/trace.go
@@ -50,7 +50,7 @@ func runQueryTrace() {
 	if err != nil {
 		ErrorAndExit(err.Error())
 	}
-	DisplayForceRecords(result)
+	DisplayForceRecordsf(result.Records, "json-pretty")
 }
 
 func runStartTrace() {

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+)
+
+var cmdTrace = &Command{
+	Run:   runTrace,
+	Usage: "trace <command>",
+	Short: "Manage trace flags",
+	Long: `
+Manage trace flags
+
+Examples:
+
+  force trace start
+
+  force trace list
+
+  force trace delete <id>
+`,
+}
+
+func init() {
+}
+
+func runTrace(cmd *Command, args []string) {
+	if len(args) == 0 {
+		cmd.printUsage()
+		return
+	}
+	switch args[0] {
+	case "list":
+		runQueryTrace()
+	case "start":
+		runStartTrace()
+	case "delete":
+		if len(args) != 2 {
+			ErrorAndExit("You need to provide the id of a TraceFlag to delete.")
+		}
+		runDeleteTrace(args[1])
+	default:
+		ErrorAndExit("no such command: %s", args[0])
+	}
+}
+
+func runQueryTrace() {
+	force, _ := ActiveForce()
+	result, err := force.QueryTraceFlags()
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+	DisplayForceRecords(result)
+}
+
+func runStartTrace() {
+	force, _ := ActiveForce()
+	_, err, _ := force.StartTrace()
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+	fmt.Printf("Tracing Enabled\n")
+}
+
+func runDeleteTrace(id string) {
+	force, _ := ActiveForce()
+	err := force.DeleteToolingRecord("TraceFlag", id)
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+	fmt.Printf("Trace Flag deleted\n")
+}


### PR DESCRIPTION
Add trace command to query the list of TraceFlag records, to enable
logging for the current user by creating a TraceFlag record, and to
delete TraceFlag records.

Store the current user id in the ForceCredentials so it doesn't have to
be parsed out of the id url.