### PR TITLE
Add eventlogfile command to list and fetch EventLogFile

### DIFF
--- a/eventlogfile.go
+++ b/eventlogfile.go
@@ -1,0 +1,34 @@
+package main
+
+import "fmt"
+
+var cmdEventLogFile = &Command{
+	Run:   getEventLogFile,
+	Usage: "eventlogfile [eventlogfileId]",
+	Short: "List and fetch event log file",
+	Long: `
+List and fetch event log file
+
+Examples:
+  force eventlogfile
+  force eventlogfile 0AT300000000XQ7GAM
+`,
+}
+
+func getEventLogFile(cmd *Command, args []string) {
+	force, _ := ActiveForce()
+	if len(args) == 0 {
+		records, err := force.QueryEventLogFiles()
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+		DisplayForceRecords(records)
+	} else {
+		logId := args[0]
+		log, err := force.RetrieveEventLogFile(logId)
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+		fmt.Println(log)
+	}
+}

--- a/force.go
+++ b/force.go
@@ -950,6 +950,26 @@ func (f *Force) QueryLogs() (results ForceQueryResult, err error) {
 	return
 }
 
+func (f *Force) RetrieveEventLogFile(elfId string) (result string, err error) {
+	url := fmt.Sprintf("%s/services/data/%s/sobjects/EventLogFile/%s/LogFile", f.Credentials.InstanceUrl, apiVersion, elfId)
+	body, err := f.httpGet(url)
+	if err != nil {
+		return
+	}
+	result = string(body)
+	return
+}
+
+func (f *Force) QueryEventLogFiles() (results ForceQueryResult, err error) {
+	url := fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType", f.Credentials.InstanceUrl, apiVersion)
+	body, err := f.httpGet(url)
+	if err != nil {
+		return
+	}
+	json.Unmarshal(body, &results)
+	return
+}
+
 func (f *Force) UpdateAuraComponent(source map[string]string, id string) (err error) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/sobjects/AuraDefinition/%s", f.Credentials.InstanceUrl, apiVersion, id)
 	_, err = f.httpPatch(url, source)

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var commands = []*Command{
 	cmdApex,
 	cmdTrace,
 	cmdLog,
+	cmdEventLogFile,
 	cmdOauth,
 	cmdTest,
 	cmdSecurity,


### PR DESCRIPTION
Hi,

I'm adding a subcommand to allow users to list and download event log files.  Salesforce event log file is a file-based, API-only feature to get Salesforce organization's application log data. 

Info about event log file: https://www.salesforce.com/us/developer/docs/api_rest/Content/using_resources_event_log_files.htm

Thanks,
Abhishek