### PR TITLE
Adds Batching for Bulk update and insert

### DIFF
--- a/bigobject.go
+++ b/bigobject.go
@@ -155,7 +155,7 @@ func getBigObjectList(args []string) (l []ForceSobject) {
 	sobjects, err := force.ListSobjects()
 	if err != nil {
 		ErrorAndExit(fmt.Sprintf("ERROR: %s\n", err))
-	} 
+	}
 
 	for _, sobject := range sobjects {
 		if len(args) == 1 {

--- a/bulk.go
+++ b/bulk.go
@@ -1,6 +1,6 @@
 package main
 
-/* 
+/*
 
 bulk command
 force bulk insert mydata.csv
@@ -55,6 +55,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io/ioutil"
+	"strings"
 )
 
 var cmdBulk = &Command{
@@ -74,7 +75,7 @@ Examples:
 
   force bulk batches [job id]
 
-  force bulk batch [job id] [batch id]
+  force Bulk batch [job id] [batch id]
 
   force bulk batch retrieve [job id] [batch id]
 
@@ -85,12 +86,15 @@ Examples:
 }
 
 func runBulk(cmd *Command, args []string) {
-
-	if len(args) == 1 {
+	if len(args) == 0 {
+		cmd.printUsage()
+	} else if len(args) == 1 {
 		ErrorAndExit("Invalid command")
 	} else if len(args) == 2 {
 		if args[0] == "insert" {
 			ErrorAndExit("Missing argument for insert")
+		} else if args[0] == "update" {
+			ErrorAndExit("Missing argument for update")
 		} else if args[0] == "job" {
 			showJobDetails(args[1])
 		} else if args[0] == "batches" {
@@ -174,11 +178,11 @@ func retrieveBulkQuery(jobId string, batchId string) (resultIds []string) {
 	}
 
 	var resultList struct {
-		Results []string `xml:"result"`
+		results []string `xml:"result"`
 	}
 
 	xml.Unmarshal(jobInfo, &resultList)
-	resultIds = resultList.Results
+	resultIds = resultList.results
 	return
 }
 
@@ -272,12 +276,13 @@ func createBulkUpdateJob(csvFilePath string, objectType string, format string) {
 	if err != nil {
 		ErrorAndExit(err.Error())
 	} else {
-		_, err := addBatchToJob(csvFilePath, jobInfo.Id)
+		batchInfo, err := addBatchToJob(csvFilePath, jobInfo.Id)
 		if err != nil {
 			closeBulkJob(jobInfo.Id)
 			ErrorAndExit(err.Error())
 		} else {
 			closeBulkJob(jobInfo.Id)
+			fmt.Printf("Job created ( %s ) - for job status use\n force bulk batch %s %s\n", jobInfo.Id, jobInfo.Id, batchInfo.Id)
 		}
 	}
 }
@@ -287,8 +292,31 @@ func addBatchToJob(csvFilePath string, jobId string) (result BatchInfo, err erro
 	force, _ := ActiveForce()
 
 	filedata, err := ioutil.ReadFile(csvFilePath)
+	batches := splitFileIntoBatches(filedata)
+	for b := range batches {
+		result, err = force.AddBatchToJob(batches[b], jobId)
+		if err != nil {
+			break
+		} else {
+			fmt.Printf("Batch %d of %d added with Id %s \n", b+1, len(batches), result.Id)
+		}
+	}
+	return
+}
 
-	result, err = force.AddBatchToJob(string(filedata), jobId)
+func splitFileIntoBatches(filedata []byte) (batches []string) {
+	batchsize := 10000
+	rows := strings.Split(string(filedata), "\n")
+	headerRow, rows := rows[0], rows[1:]
+	for len(rows) > 1 {
+		if len(rows) < batchsize {
+			batchsize = len(rows)
+		}
+		batch := []string{headerRow}
+		batch = append(batch, rows[0:batchsize]...)
+		batches = append(batches, strings.Join(batch, "\n"))
+		rows = rows[batchsize:]
+	}
 	return
 }
 

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	//"fmt"
-) 
+)
 
 var Config = config.NewConfig("force")
 

--- a/datapipe.go
+++ b/datapipe.go
@@ -66,7 +66,7 @@ var (
 	scripttype    string
 	query         string
 	format        string
-	jobid		  string
+	jobid         string
 )
 
 func init() {
@@ -142,7 +142,7 @@ func runDataPipelineListJobs() {
 	}
 
 	DisplayForceRecordsf(result.Records, "csv")
-} 
+}
 
 func runDataPipelineQueryJob() {
 	//query = "SELECT Id, DataPipeline.DeveloperName, Status, FailureState, LastModifiedDate, CreatedDate, CreatedById, DataPipelineId, JobErrorMessage FROM DataPipelineJob"
@@ -186,7 +186,7 @@ func runDataPipelineCreate() {
 }
 
 func runDataPipelineUpdate() {
-	if len(dpname) == 0 { 
+	if len(dpname) == 0 {
 		ErrorAndExit("You must specify a name for the datapipeline using the -n flag.")
 	}
 	if len(masterlabel) == 0 && len(scriptcontent) == 0 {

--- a/display.go
+++ b/display.go
@@ -319,7 +319,7 @@ func StringSlicePos(slice []string, value string) int {
 		}
 	}
 	return -1
-} 
+}
 
 // returns true if a slice contains given string
 func StringSliceContains(slice []string, value string) bool {

--- a/fetch.go
+++ b/fetch.go
@@ -254,7 +254,7 @@ func runFetch(cmd *Command, args []string) {
 				isResource = true
 			} else if strings.HasSuffix(file, ".resource-meta.xml") {
 				isResource = true
-			} 
+			}
 			//Handle expanding static resources into a "bundle" folder
 			if isResource && expandResources {
 				if string(os.PathSeparator) != "/" {

--- a/force.go
+++ b/force.go
@@ -533,8 +533,8 @@ func (f *Force) GetAuraBundleDefinitions() (definitions AuraDefinitionBundleResu
 	}
 	json.Unmarshal(body, &definitions)
 
-	if (!definitions.Done) {
-		f.GetMoreAuraBundleDefinitions(&definitions)	
+	if !definitions.Done {
+		f.GetMoreAuraBundleDefinitions(&definitions)
 	}
 
 	return
@@ -544,28 +544,28 @@ func (f *Force) GetMoreAuraBundleDefinitions(definitions *AuraDefinitionBundleRe
 
 	isDone := definitions.Done
 	nextRecordsUrl := definitions.NextRecordsUrl
-	
+
 	for !isDone {
-	
-		moreDefs := new (AuraDefinitionBundleResult)
+
+		moreDefs := new(AuraDefinitionBundleResult)
 		aurl := fmt.Sprintf("%s%s", f.Credentials.InstanceUrl, nextRecordsUrl)
-		
+
 		body, err := f.httpGet(aurl)
 		if err != nil {
 			return err
 		}
 		json.Unmarshal(body, &moreDefs)
-		
+
 		definitions.Done = moreDefs.Done
 		definitions.Records = append(definitions.Records, moreDefs.Records...)
-		
+
 		isDone = moreDefs.Done
-		
-		if (!isDone) {
+
+		if !isDone {
 			nextRecordsUrl = moreDefs.NextRecordsUrl
-		}        
+		}
 	}
-	
+
 	return
 }
 
@@ -608,7 +608,7 @@ func (f *Force) GetAuraBundleByName(bundleName string) (bundles AuraDefinitionBu
 
 func (f *Force) GetAuraBundleDefinition(id string) (definitions AuraDefinitionBundleResult, err error) {
 	aurl := fmt.Sprintf("%s/services/data/%s/tooling/query?q=%s", f.Credentials.InstanceUrl, apiVersion,
-		url.QueryEscape(fmt.Sprintf("SELECT Id, Source, AuraDefinitionBundleId, DefType, Format FROM AuraDefinition WHERE AuraDefinitionBundleId = '%s'", id)))		
+		url.QueryEscape(fmt.Sprintf("SELECT Id, Source, AuraDefinitionBundleId, DefType, Format FROM AuraDefinition WHERE AuraDefinitionBundleId = '%s'", id)))
 
 	body, err := f.httpGet(aurl)
 	if err != nil {

--- a/log.go
+++ b/log.go
@@ -39,4 +39,3 @@ func getLog(cmd *Command, args []string) {
 		fmt.Println(log)
 	}
 }
-

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ var commands = []*Command{
 	cmdWhoami,
 	cmdDescribe,
 	cmdSobject,
-	cmdBigObject, 
+	cmdBigObject,
 	cmdField,
 	cmdRecord,
 	cmdBulk,

--- a/metadata.go
+++ b/metadata.go
@@ -295,7 +295,7 @@ type MetadataDescribeResult struct {
 	PartialSaveAllowed bool                     `xml:"partialSaveAllowed"`
 	TestRequired       bool                     `xml:"testRequired"`
 	MetadataObjects    []DescribeMetadataObject `xml:"metadataObjects"`
-} 
+}
 
 type MetadataDescribeValueTypeResult struct {
 	ValueTypeFields []MetadataValueTypeField `xml:"result"`

--- a/metadata2.go
+++ b/metadata2.go
@@ -13,7 +13,7 @@ package main
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv" 
+	"strconv"
 	"strings"
 	"time"
 )*/

--- a/pushAura.go
+++ b/pushAura.go
@@ -1,6 +1,6 @@
 package main
 
-import ( 
+import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"


### PR DESCRIPTION
Splits the input file into batches of 10k rows with the header
row retained. This feature was limited to a single batch of <10k
records previously. Can now handle very large files.
Go fmt also run which affected other files