### PR TITLE
Fix Large Query Support

### DIFF
--- a/force.go
+++ b/force.go
@@ -685,6 +685,7 @@ func (f *Force) Query(query string) (result ForceQueryResult, err error) {
 			if nextErr != nil {
 				return
 			}
+			nextResult.Records = []ForceRecord{}
 			json.Unmarshal(nextBody, &nextResult)
 
 			result.Records = append(result.Records, nextResult.Records...)


### PR DESCRIPTION
Experienced a problem when running large queries where the Interface
slice isn't reset and holds the previous records instead of receiving the new data.
Any data over 4000 records will just be replaced by the 2001-4000 records block over and over again.

Replicate by querying any set of IDs with at least 4001 records. Unique the returned IDs and you'll find that repetition pattern.

I haven't yet determined if this is correct behavior in Go but the docs for json.Unmarshal suggest that objects should be cleared before Unmarshaling. I believe it may be a Go problem we're working around. I don't know enough Go to say for sure. I'll try and find out but the workaround should be reliable either way.
https://golang.org/pkg/encoding/json/
