### PR TITLE
Updating command help to set Active Account

### DIFF
--- a/active.go
+++ b/active.go
@@ -9,7 +9,7 @@ import (
 )
 
 var cmdActive = &Command{
-	Usage: "active [account]",
+	Usage: "active -a [account]",
 	Short: "Show or set the active force.com account",
 	Long: `
 Set the active force.com account
@@ -17,7 +17,7 @@ Set the active force.com account
 Examples:
 
   force active
-  force active user@example.org
+  force active -a user@example.org
 `,
 }
 var (


### PR DESCRIPTION
Fixed the example command to set active Salesforce instance command.