### PR TITLE
Allow Setting TraceFlags For Other Users

### DIFF
--- a/force.go
+++ b/force.go
@@ -914,7 +914,7 @@ func (f *Force) QueryTraceFlags() (results ForceQueryResult, err error) {
 	return
 }
 
-func (f *Force) StartTrace() (result ForceCreateRecordResult, err error, emessages []ForceError) {
+func (f *Force) StartTrace(userId ...string) (result ForceCreateRecordResult, err error, emessages []ForceError) {
 	url := fmt.Sprintf("%s/services/data/%s/tooling/sobjects/TraceFlag", f.Credentials.InstanceUrl, apiVersion)
 
 	// The log levels are currently hard-coded to a useful level of logging
@@ -928,7 +928,11 @@ func (f *Force) StartTrace() (result ForceCreateRecordResult, err error, emessag
 	attrs["Validation"] = "Warn"
 	attrs["Visualforce"] = "Info"
 	attrs["Workflow"] = "Info"
-	attrs["TracedEntityId"] = f.Credentials.UserId
+	if len(userId) == 1 {
+		attrs["TracedEntityId"] = userId[0]
+	} else {
+		attrs["TracedEntityId"] = f.Credentials.UserId
+	}
 
 	body, err, emessages := f.httpPost(url, attrs)
 	if err != nil {

--- a/trace.go
+++ b/trace.go
@@ -13,7 +13,7 @@ Manage trace flags
 
 Examples:
 
-  force trace start
+  force trace start [user id]
 
   force trace list
 
@@ -33,7 +33,11 @@ func runTrace(cmd *Command, args []string) {
 	case "list":
 		runQueryTrace()
 	case "start":
-		runStartTrace()
+		if len(args) == 2 {
+			runStartTrace(args[1])
+		} else {
+			runStartTrace()
+		}
 	case "delete":
 		if len(args) != 2 {
 			ErrorAndExit("You need to provide the id of a TraceFlag to delete.")
@@ -53,9 +57,9 @@ func runQueryTrace() {
 	DisplayForceRecordsf(result.Records, "json-pretty")
 }
 
-func runStartTrace() {
+func runStartTrace(userId ...string) {
 	force, _ := ActiveForce()
-	_, err, _ := force.StartTrace()
+	_, err, _ := force.StartTrace(userId...)
 	if err != nil {
 		ErrorAndExit(err.Error())
 	}


### PR DESCRIPTION
Add optional user id option to `force trace start`.  If passed, a
TraceFlag record is created for the specified user; otherwise one is
created for the authenticated user.