### PR TITLE
Specify Test Level and Tests To Run During Deploy

### DIFF
--- a/import.go
+++ b/import.go
@@ -17,11 +17,13 @@ Import metadata from a local directory
 
 Deployment Options
   -rollbackonerror, -r    Indicates whether any failure causes a complete rollback
-  -runalltests, -t        If set all Apex tests defined in the organization are run
+  -runalltests, -t        If set all Apex tests defined in the organization are run (equivalent to -l RunAllTestsInOrg)
   -checkonly, -c          Indicates whether classes and triggers are saved during deployment
   -purgeondelete, -p      If set the deleted components are not stored in recycle bin
   -allowmissingfiles, -m  Specifies whether a deploy succeeds even if files missing
   -autoupdatepackage, -u  Auto add files to the package if missing
+  -test                   Run tests in class (implies -l RunSpecifiedTests)
+  -testlevel, -l          Set test level (NoTestRun, RunSpecifiedTests, RunLocalTests, RunAllTestsInOrg)
   -ignorewarnings, -i     Indicates if warnings should fail deployment or not
   -directory, -d 		  Path to the package.xml file to import
   -verbose, -v 			  Provide detailed feedback on operation
@@ -37,8 +39,10 @@ Examples:
 }
 
 var (
+	testsToRun            metaName
 	rollBackOnErrorFlag   = cmdImport.Flag.Bool("rollbackonerror", false, "set roll back on error")
 	runAllTestsFlag       = cmdImport.Flag.Bool("runalltests", false, "set run all tests")
+	testLevelFlag         = cmdImport.Flag.String("testLevel", "NoTestRun", "set test level")
 	checkOnlyFlag         = cmdImport.Flag.Bool("checkonly", false, "set check only")
 	purgeOnDeleteFlag     = cmdImport.Flag.Bool("purgeondelete", false, "set purge on delete")
 	allowMissingFilesFlag = cmdImport.Flag.Bool("allowmissingfiles", false, "set allow missing files")
@@ -53,12 +57,14 @@ func init() {
 	cmdImport.Flag.BoolVar(verbose, "v", false, "give more verbose output")
 	cmdImport.Flag.BoolVar(rollBackOnErrorFlag, "r", false, "set roll back on error")
 	cmdImport.Flag.BoolVar(runAllTestsFlag, "t", false, "set run all tests")
+	cmdImport.Flag.StringVar(testLevelFlag, "l", "NoTestRun", "set test level")
 	cmdImport.Flag.BoolVar(checkOnlyFlag, "c", false, "set check only")
 	cmdImport.Flag.BoolVar(purgeOnDeleteFlag, "p", false, "set purge on delete")
 	cmdImport.Flag.BoolVar(allowMissingFilesFlag, "m", false, "set allow missing files")
 	cmdImport.Flag.BoolVar(autoUpdatePackageFlag, "u", false, "set auto update package")
 	cmdImport.Flag.BoolVar(ignoreWarningsFlag, "i", false, "set ignore warnings")
 	cmdImport.Flag.StringVar(directory, "d", "metadata", "relative path to package.xml")
+	cmdImport.Flag.Var(&testsToRun, "test", "Test(s) to run")
 }
 
 func runImport(cmd *Command, args []string) {
@@ -120,7 +126,11 @@ func runImport(cmd *Command, args []string) {
 	DeploymentOptions.IgnoreWarnings = *ignoreWarningsFlag
 	DeploymentOptions.PurgeOnDelete = *purgeOnDeleteFlag
 	DeploymentOptions.RollbackOnError = *rollBackOnErrorFlag
-	DeploymentOptions.RunAllTests = *runAllTestsFlag
+	DeploymentOptions.TestLevel = *testLevelFlag
+	if *runAllTestsFlag {
+		DeploymentOptions.TestLevel = "RunAllTestsInOrg"
+	}
+	DeploymentOptions.RunTests = testsToRun
 
 	result, err := force.Metadata.Deploy(files, DeploymentOptions)
 	problems := result.Details.ComponentFailures

--- a/metadata.go
+++ b/metadata.go
@@ -191,7 +191,7 @@ type ForceDeployOptions struct {
 	PerformRetrieve   bool     `xml:"performRetrieve"`
 	PurgeOnDelete     bool     `xml:"purgeOnDelete"`
 	RollbackOnError   bool     `xml:"rollbackOnError"`
-	RunAllTests       bool     `xml:"runAllTests"`
+	TestLevel         string   `xml:"testLevel"`
 	RunTests          []string `xml:"runTests"`
 	SinglePackage     bool     `xml:"singlePackage"`
 }
@@ -1064,6 +1064,16 @@ func (fm *ForceMetadata) DeleteCustomObject(object string) (err error) {
 }
 
 func (fm *ForceMetadata) MakeDeploySoap(options ForceDeployOptions) (soap string) {
+	tests := ""
+	for _, test := range options.RunTests {
+		tests += "<runTests>" + test + "</runTests>\n"
+	}
+	var testLevel string
+	if tests == "" {
+		testLevel = options.TestLevel
+	} else {
+		testLevel = "RunSpecifiedTests"
+	}
 	soap = fmt.Sprintf(`
 		<zipFile>%s</zipFile>
 		<deployOptions>
@@ -1073,9 +1083,10 @@ func (fm *ForceMetadata) MakeDeploySoap(options ForceDeployOptions) (soap string
 			<ignoreWarnings>%t</ignoreWarnings>
 			<purgeOnDelete>%t</purgeOnDelete>
 			<rollbackOnError>%t</rollbackOnError>
-			<runAllTests>%t</runAllTests>
+			<testLevel>%s</testLevel>
+			%s
 		</deployOptions>
-	`, "%s", options.AllowMissingFiles, options.AutoUpdatePackage, options.CheckOnly, options.IgnoreWarnings, options.PurgeOnDelete, options.RollbackOnError, options.RunAllTests)
+		`, "%s", options.AllowMissingFiles, options.AutoUpdatePackage, options.CheckOnly, options.IgnoreWarnings, options.PurgeOnDelete, options.RollbackOnError, testLevel, tests)
 	return
 }
 

--- a/push.go
+++ b/push.go
@@ -31,11 +31,13 @@ Examples:
 
 Deployment Options
   -rollbackonerror, -r    Indicates whether any failure causes a complete rollback
-  -runalltests, -at        If set all Apex tests defined in the organization are run
+  -runalltests, -at       If set all Apex tests defined in the organization are run (equivalent to -l RunAllTestsInOrg)
   -checkonly, -c          Indicates whether classes and triggers are saved during deployment
   -purgeondelete, -p      If set the deleted components are not stored in recycle bin
   -allowmissingfiles, -m  Specifies whether a deploy succeeds even if files missing
   -autoupdatepackage, -u  Auto add files to the package if missing
+  -test                   Run tests in class (implies -l RunSpecifiedTests)
+  -testlevel, -l          Set test level (NoTestRun, RunSpecifiedTests, RunLocalTests, RunAllTestsInOrg)
   -ignorewarnings, -i     Indicates if warnings should fail deployment or not
 `,
 }
@@ -55,6 +57,8 @@ func init() {
 	cmdPush.Flag.BoolVar(rollBackOnErrorFlag, "r", false, "set roll back on error")
 	cmdPush.Flag.BoolVar(runAllTestsFlag, "runalltests", false, "set run all tests")
 	cmdPush.Flag.BoolVar(runAllTestsFlag, "at", false, "set run all tests")
+	cmdPush.Flag.StringVar(testLevelFlag, "testlevel", "NoTestRun", "set test level")
+	cmdPush.Flag.StringVar(testLevelFlag, "l", "NoTestRun", "set test level")
 	cmdPush.Flag.BoolVar(checkOnlyFlag, "checkonly", false, "set check only")
 	cmdPush.Flag.BoolVar(checkOnlyFlag, "c", false, "set check only")
 	cmdPush.Flag.BoolVar(purgeOnDeleteFlag, "purgeondelete", false, "set purge on delete")
@@ -68,6 +72,7 @@ func init() {
 
 	cmdPush.Flag.Var(&resourcepath, "f", "Path to resource(s)")
 	cmdPush.Flag.Var(&resourcepath, "filepath", "Path to resource(s)")
+	cmdPush.Flag.Var(&testsToRun, "test", "Test(s) to run")
 	cmdPush.Flag.StringVar(&metadataType, "t", "", "Metatdata type")
 	cmdPush.Flag.StringVar(&metadataType, "type", "", "Metatdata type")
 	cmdPush.Flag.Var(&metadataName, "name", "name of metadata object")
@@ -518,7 +523,11 @@ func deployOpts() *ForceDeployOptions {
 	opts.IgnoreWarnings = *ignoreWarningsFlag
 	opts.PurgeOnDelete = *purgeOnDeleteFlag
 	opts.RollbackOnError = *rollBackOnErrorFlag
-	opts.RunAllTests = *runAllTestsFlag
+	opts.TestLevel = *testLevelFlag
+	if *runAllTestsFlag {
+		opts.TestLevel = "RunAllTestsInOrg"
+	}
+	opts.RunTests = testsToRun
 	return &opts
 }
 


### PR DESCRIPTION
Add support for specifying the test level and tests to run to the push
and import commands.

By default, the test level is NoTestRun.  If any test classes are
specified, the test level is set to RunSpecifiedTests.

The -runalltests option is preserved, and is equivalent to the new
RunAllTestsInOrg test level.