### PR TITLE
Update README.md for "force active" to reflect actual behavior when changing users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Logins will list all the user names that you have used to authenticate with the 
 Active without any arguments will display the currently acctive login that you are using. You can also supply a username argument that will set the active login to the one corresponding to the username argument. Note, just because you set a login as active, does not mean that the token is necessarily valid.
 
       force active
-      force active dave@demo.1
+      force active -a dave@demo.1
 
 ### whoami
 Whoami will display detailed user information about the currently active logged in user.  This is Force.com specific information.


### PR DESCRIPTION
The documentation does not specify that the usage of ```force active [username]``` required a ```-a```, so the proper documentation should show ```force active -a [username]``` flag in order to change the active user. This updates the documentation for proper usage of the ```active``` sub-command.