### PR TITLE
Error When No Tests Run

### DIFF
--- a/partner.go
+++ b/partner.go
@@ -11,9 +11,14 @@ type ForcePartner struct {
 	Force *Force
 }
 
+type TestRunner interface {
+	RunTests(tests []string, namespace string) (output TestCoverage, err error)
+}
+
 type TestCoverage struct {
 	Log                       string   `xml:"Header>DebuggingInfo>debugLog"`
 	NumberRun                 int      `xml:"Body>runTestsResponse>result>numTestsRun"`
+	NumberFailures            int      `xml:"Body>runTestsResponse>result>numFailures"`
 	NumberLocations           []int    `xml:"Body>runTestsResponse>result>codeCoverage>numLocations"`
 	NumberLocationsNotCovered []int    `xml:"Body>runTestsResponse>result>codeCoverage>numLocationsNotCovered"`
 	Name                      []string `xml:"Body>runTestsResponse>result>codeCoverage>name"`

--- a/test.go
+++ b/test.go
@@ -34,55 +34,60 @@ var (
 	verboselogging    bool
 )
 
+func RunTests(testRunner TestRunner, tests []string, namespace string) (output TestCoverage, err error) {
+	output, err = testRunner.RunTests(tests, namespace)
+	if err != nil {
+		return
+	}
+	if output.NumberRun == 0 && output.NumberFailures == 0 {
+		err = fmt.Errorf("Test classes specified not found: %v", tests)
+		return
+	}
+	return
+}
+
 func runTests(cmd *Command, args []string) {
 	if len(args) < 1 {
 		ErrorAndExit("must specify tests to run")
 	}
 	force, _ := ActiveForce()
-	output, err := force.Partner.RunTests(args, *namespaceTestFlag)
+	output, err := RunTests(force.Partner, args, *namespaceTestFlag)
 	success := false
 	if err != nil {
 		ErrorAndExit(err.Error())
-	} else {
-
-		if verboselogging {
-			fmt.Println(output.Log)
-			fmt.Println()
-		}
-		//working on a better way to do this - catches when no class are found and ran
-		if output.NumberRun == 0 {
-			fmt.Println("Test classes specified not found")
-		} else {
-			var percent string
-			fmt.Println("Coverage:")
-			fmt.Println()
-			for index := range output.NumberLocations {
-				if output.NumberLocations[index] != 0 {
-					percent = strconv.Itoa(((output.NumberLocations[index]-output.NumberLocationsNotCovered[index])/output.NumberLocations[index])*100) + "%"
-				} else {
-					percent = "0%"
-				}
-				fmt.Println("  " + percent + "   " + output.Name[index])
-			}
-			fmt.Println()
-			fmt.Println()
-			fmt.Println("Results:")
-			fmt.Println()
-			for index := range output.SMethodNames {
-				fmt.Println("  [PASS]  " + output.SClassNames[index] + "::" + output.SMethodNames[index])
-			}
-
-			for index := range output.FMethodNames {
-				fmt.Println("  [FAIL]  " + output.FClassNames[index] + "::" + output.FMethodNames[index] + ": " + output.FMessage[index])
-				fmt.Println("    " + output.FStackTrace[index])
-			}
-			fmt.Println()
-			fmt.Println()
-
-			success = len(output.FMethodNames) == 0
-		}
-
-		// Handle notifications
-		notifySuccess("test", success)
 	}
+	if verboselogging {
+		fmt.Println(output.Log)
+		fmt.Println()
+	}
+	var percent string
+	fmt.Println("Coverage:")
+	fmt.Println()
+	for index := range output.NumberLocations {
+		if output.NumberLocations[index] != 0 {
+			percent = strconv.Itoa(((output.NumberLocations[index]-output.NumberLocationsNotCovered[index])/output.NumberLocations[index])*100) + "%"
+		} else {
+			percent = "0%"
+		}
+		fmt.Println("  " + percent + "   " + output.Name[index])
+	}
+	fmt.Println()
+	fmt.Println()
+	fmt.Println("Results:")
+	fmt.Println()
+	for index := range output.SMethodNames {
+		fmt.Println("  [PASS]  " + output.SClassNames[index] + "::" + output.SMethodNames[index])
+	}
+
+	for index := range output.FMethodNames {
+		fmt.Println("  [FAIL]  " + output.FClassNames[index] + "::" + output.FMethodNames[index] + ": " + output.FMessage[index])
+		fmt.Println("    " + output.FStackTrace[index])
+	}
+	fmt.Println()
+	fmt.Println()
+
+	success = len(output.FMethodNames) == 0
+
+	// Handle notifications
+	notifySuccess("test", success)
 }

--- a/test_test.go
+++ b/test_test.go
@@ -1,0 +1,48 @@
+package main_test
+
+import (
+	. "github.com/heroku/force"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type stubTestRunner struct {
+}
+
+func (testRunner stubTestRunner) RunTests(tests []string, namespace string) (output TestCoverage, err error) {
+	if tests[0] == "NoSuchTest" {
+		output = TestCoverage{NumberRun: 0, NumberFailures: 0}
+	} else if tests[0] == "Success" {
+		output = TestCoverage{NumberRun: 1, NumberFailures: 0}
+	} else {
+		output = TestCoverage{NumberRun: 1, NumberFailures: 1}
+	}
+	return
+}
+
+var _ = Describe("Test", func() {
+	var (
+		stub stubTestRunner
+	)
+
+	BeforeEach(func() {
+		stub = stubTestRunner{}
+	})
+
+	Describe("RunTests", func() {
+		It("should return an error if no tests can be run", func() {
+			_, err := RunTests(stub, []string{"NoSuchTest"}, "")
+			Expect(err).To(HaveOccurred())
+		})
+		It("should not return an error if tests pass", func() {
+			_, err := RunTests(stub, []string{"Success"}, "")
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should not return an error if tests fail", func() {
+			_, err := RunTests(stub, []string{"Fail"}, "")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+})


### PR DESCRIPTION
Display the error(s) when no tests are run using `force test`.

Fixes bug in which "Test classes specified not found" was reported
incorrectly in the case where there were no tests successfully run.
This can happen when previously deployed apex upon which the test is
dependent can no longer be compiled, for example.

*(I created a new interface, `TestRunner`, so I can stub out* 
```
func (partner *ForcePartner) RunTests(tests []string, namespace string) (output TestCoverage, err error)
```
*in the tests.  This seems to be the recommended approach in the ginkgo docs.  @dcarroll, are you happy with this approach?)*