### PR TITLE
Bugfix for `force bulk query retrieve` to parse resultIds

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -178,11 +178,11 @@ func retrieveBulkQuery(jobId string, batchId string) (resultIds []string) {
 	}
 
 	var resultList struct {
-		results []string `xml:"result"`
+		Results []string `xml:"result"`
 	}
 
 	xml.Unmarshal(jobInfo, &resultList)
-	resultIds = resultList.results
+	resultIds = resultList.Results
 	return
 }
 


### PR DESCRIPTION
Prior commit included a variable naming convention change which apparently wasn't compiled when tested, therefore introducing a bug. This fixes that issue, therefore allowing `force bulk query retrieve to work`

*This reapplies 65b37f1e131830f14eef495a33e3b8a38d4ac7c0 to fix the regression bug introduced in a874ed9a3abd38abd4bc1dd72917b9fb3b2cedee.*