### PR TITLE
Support Proxy Server

### DIFF
--- a/force.go
+++ b/force.go
@@ -1203,7 +1203,7 @@ func httpClient() (client *http.Client) {
 			config.RootCAs.AddCert(x509Cert)
 		}
 		config.BuildNameToCertificate()
-		tr := http.Transport{TLSClientConfig: &config}
+		tr := http.Transport{TLSClientConfig: &config, Proxy: http.ProxyFromEnvironment}
 		client = &http.Client{Transport: &tr}
 	} else {
 		client = &http.Client{}


### PR DESCRIPTION
Use the proxy server defined by the standard environment variables,
HTTP_PROXY, HTTPS_PROXY, and NO_PROXY, if set.