### PR TITLE
Store UserId When Using OAuth Login

### DIFF
--- a/login.go
+++ b/login.go
@@ -116,6 +116,8 @@ func ForceSaveLogin(creds ForceCredentials) (username string, err error) {
 		return
 	}
 
+	userId := login["user_id"].(string)
+	creds.UserId = userId
 	username = login["username"].(string)
 
 	me, err := force.Whoami()


### PR DESCRIPTION
When logging in using OAuth, store the user's Id with the credentials.

Fixes bug in which `force trace start` fails when not passed a user id
while logged in using OAuth.