### PR TITLE
Fix force login with custom domains

### DIFF
--- a/force.go
+++ b/force.go
@@ -234,7 +234,7 @@ func ForceSoapLogin(endpoint ForceEndpoint, username string, password string) (c
 	case EndpointCustom:
 		surl = fmt.Sprintf("%s/services/Soap/u/%s", CustomEndpoint, version)
 	default:
-		ErrorAndExit("no such endpoint type")
+		ErrorAndExit("Unable to login with SOAP. Unknown endpoint type")
 	}
 
 	soap := NewSoap(surl, "", "")
@@ -296,8 +296,10 @@ func ForceLogin(endpoint ForceEndpoint) (creds ForceCredentials, err error) {
 		url = fmt.Sprintf("https://prerellogin.pre.salesforce.com/services/oauth2/authorize?response_type=token&client_id=%s&redirect_uri=%s&state=%d&prompt=login", PrereleaseClientId, Redir, port)
 	case EndpointMobile1:
 		url = fmt.Sprintf("https://EndpointMobile1.t.salesforce.com/services/oauth2/authorize?response_type=token&client_id=%s&redirect_uri=%s&state=%d&prompt=login", Mobile1ClientId, Redir, port)
+	case EndpointCustom:
+		url = fmt.Sprintf("%s/services/oauth2/authorize?response_type=token&client_id=%s&redirect_uri=%s&state=%d&prompt=login", CustomEndpoint, ProductionClientId, Redir, port)
 	default:
-		ErrorAndExit("no such endpoint type")
+		ErrorAndExit("Unable to login with OAuth. Unknown endpoint type")
 	}
 
 	err = Open(url)

--- a/login.go
+++ b/login.go
@@ -37,11 +37,14 @@ var (
 func runLogin(cmd *Command, args []string) {
 	var endpoint ForceEndpoint = EndpointProduction
 
-	currentEndpoint, customUrl, err := CurrentEndpoint()
-	if err == nil && &currentEndpoint != nil {
-		endpoint = currentEndpoint
-		if currentEndpoint == EndpointCustom && customUrl != "" {
-			*instance = customUrl
+	// If no instance specified, try to get last endpoint used
+	if *instance == "" {
+		currentEndpoint, customUrl, err := CurrentEndpoint()
+		if err == nil && &currentEndpoint != nil {
+			endpoint = currentEndpoint
+			if currentEndpoint == EndpointCustom && customUrl != "" {
+				*instance = customUrl
+			}
 		}
 	}
 
@@ -57,14 +60,14 @@ func runLogin(cmd *Command, args []string) {
 			//need to determine the form of the endpoint
 			uri, err := url.Parse(*instance)
 			if err != nil {
-				ErrorAndExit("no such endpoint: %s", *instance)
+				ErrorAndExit("Unable to parse endpoint: %s", *instance)
 			}
 			// Could be short hand?
 			if uri.Host == "" {
 				uri, err = url.Parse(fmt.Sprintf("https://%s", *instance))
 				//fmt.Println(uri)
 				if err != nil {
-					ErrorAndExit("no such endpoint: %s", *instance)
+					ErrorAndExit("Could not identify host: %s", *instance)
 				}
 			}
 			CustomEndpoint = uri.Scheme + "://" + uri.Host


### PR DESCRIPTION
Fixes a bug where the previous custom domain would override any new
custom domains from the command line.

This patch also addes slightly more descriptive errors to help narrow
down issues in the future.

Another bonus: OAuth authentication using custom domains as well

This patch fixes #262