### PR TITLE
Make src a valid source directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ Can be downloaded from the [Current Realease Page](https://github.com/heroku/for
 ### login
 When you login using the CLI a record of the login is saved. Eventually your token will expire requiring re-authentication. The default login is for all production instances of salesforce.com. Two predefined non-production instances are available using the test and pre aliases.  You can set an arbitrary instance to log in to by specifying the instance url in the form of subdomain.domain. For example login-blitz.soma.salesforce.com.
 
-      force login               # log in to production or developer org
-      force login -i=test           # log in to sandbox org
-      force login -i=pre            # log in to prerelease org
-      force login -u=un -p=pw       # log in using SOAP
-      force login -i=test -u=un -p=pw       # log in using SOAP to sandbox org
-      force login -i=<instance> -u=un -p=pw     # internal only
+      force login                           # log in to last environment
+      force login -i=login                  # log in to production or developer org
+      force login -i=test                   # log in to sandbox org
+      force login -i=pre                    # log in to prerelease org
+      force login -u=un [-p=pw]             # log in using SOAP. Password is optional
+      force login -i=test -u=un -p=pw       # log in using SOAP to sandbox org. Password is optional
+      force login -i=<instance> -u=un -p=pw # internal only
 
 ### logout
 Logout will delete your authentication token and remove the saved record of that login.

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ var Config = config.NewConfig("force")
 func GetSourceDir() (src string, err error) {
 	// Last element is default
 	var sourceDirs = []string{
-		//"src",
+		"src",
 		"metadata",
 	}
 

--- a/export.go
+++ b/export.go
@@ -24,10 +24,15 @@ Examples:
 }
 
 func runExport(cmd *Command, args []string) {
-	wd, _ := os.Getwd()
-	root := filepath.Join(wd, "metadata")
+	// Get path from args if available
+	var err error
+	var root string
 	if len(args) == 1 {
-		root, _ = filepath.Abs(args[0])
+		root, err = filepath.Abs(args[0])
+	}
+	if err != nil {
+		fmt.Printf("Error obtaining file path\n")
+		ErrorAndExit(err.Error())
 	}
 	force, _ := ActiveForce()
 	sobjects, err := force.ListSobjects()
@@ -133,6 +138,11 @@ func runExport(cmd *Command, args []string) {
 	files, err := force.Metadata.Retrieve(query)
 	if err != nil {
 		fmt.Printf("Encountered and error with retrieve...\n")
+		ErrorAndExit(err.Error())
+	}
+	root, err = GetSourceDir()
+	if err != nil {
+		fmt.Printf("Error obtaining root directory\n")
 		ErrorAndExit(err.Error())
 	}
 	for name, data := range files {

--- a/fetch.go
+++ b/fetch.go
@@ -233,6 +233,10 @@ func runFetch(cmd *Command, args []string) {
 	resourcesMap = make(map[string]string)
 
 	root, err := GetSourceDir()
+	if err != nil {
+		fmt.Printf("Error obtaining root directory\n")
+		ErrorAndExit(err.Error())
+	}
 	existingPackage, _ := pathExists(filepath.Join(root, "package.xml"))
 
 	if len(files) == 1 {


### PR DESCRIPTION
This was previously merged but reverted. This re-enables the feature
again. It was reverted because there were other locations where the path
was hard coded to look at a directory named 'metadata'. If those
situations arise again, instead of hard coding, they should use
`GetSrcDir()` to obtain the true path. This will not only provide
flexibility for src vs metadata, but allow any future conventions to be
easily supported.

Closes #176