### PR TITLE
Deploy Global Picklists

### DIFF
--- a/packagebuilder.go
+++ b/packagebuilder.go
@@ -52,6 +52,7 @@ var metapaths = []metapath{
 	metapath{path: "flexipages", name: "FlexiPage"},
 	metapath{path: "flowDefinitions", name: "FlowDefinition"},
 	metapath{path: "flows", name: "Flow"},
+	metapath{path: "globalPicklists", name: "GlobalPicklist"},
 	metapath{path: "groups", name: "Group"},
 	metapath{path: "homePageLayouts", name: "HomePageLayout"},
 	metapath{path: "installedPackages", name: "InstalledPackage"},


### PR DESCRIPTION
Add support for deploying Global Picklists, available as of Summer '16,
with `force push`.