### PR TITLE
Update describe help text

### DIFF
--- a/describe.go
+++ b/describe.go
@@ -14,10 +14,8 @@ var cmdDescribe = &Command{
 
   Examples
 
-  force describe metadata -n=CustomObject
-  force describe sobject -n=Account
-  force describe metata
-  force describe sobject
+  force describe -t=metadata -n=CustomObject
+  force describe -t=sobject -n=Account
   `,
 }
 


### PR DESCRIPTION
As far as I can tell from use, the describe function fails unless the `-t` flag is explicitly set. This commit also removes what I think are two extraneous lines.