### PR TITLE
add correct extension when fetching interfaces

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -168,6 +168,8 @@ func persistBundles(bundles AuraDefinitionBundleResult, definitions AuraDefiniti
 					entity += ".svg"
 				case "DESIGN":
 					entity += ".design"
+				case "INTERFACE":
+					entity += ".intf"
 				default:
 					entity += fmt.Sprintf("%s.js", naming)
 				}


### PR DESCRIPTION
Current version is fetching interfaces like `TestInterface.intf` as `TestInterfaceInterface.js`