### PR TITLE
Quote quotes in CSV-formatted output

### DIFF
--- a/display.go
+++ b/display.go
@@ -354,7 +354,10 @@ func RenderForceRecordsCSV(records []ForceRecord, format string) string {
 		for _, record := range flattenedRecords {
 			myvalues := make([]string, len(keys))
 			for i, key := range keys {
-				myvalues[i] = strings.Replace(fmt.Sprintf(`%v`, record[key]), "<nil>", "", -1)
+				var value = fmt.Sprintf(`%v`, record[key])
+				value = strings.Replace(value, "<nil>", "", -1)
+				value = strings.Replace(value, `"`, `""`, -1)
+				myvalues[i] = value
 			}
 			out.WriteString(fmt.Sprintf(`"%s"%s`, strings.Join(myvalues, `","`), "\n"))
 		}


### PR DESCRIPTION
Fixes #315 by replacing double quotes in CSV output with two double quotes. Based on the current behaviour of always quoting all output fields, this approach should always yield correctly-escaped quotation marks.