### PR TITLE
Added check for hourly permissions and version >= 37 before querying …

### DIFF
--- a/apiversion.go
+++ b/apiversion.go
@@ -31,7 +31,7 @@ func runApiVersion(cmd *Command, args []string) {
 		apiVersionNumber = args[0]
 		apiVersion = "v" + apiVersionNumber
 		force.Credentials.ApiVersion = apiVersionNumber
-                ForceSaveLogin(*force.Credentials)
+		ForceSaveLogin(*force.Credentials)
 	} else if len(args) == 0 {
 		fmt.Println(apiVersion)
 	} else {

--- a/apiversion.go
+++ b/apiversion.go
@@ -31,7 +31,7 @@ func runApiVersion(cmd *Command, args []string) {
 		apiVersionNumber = args[0]
 		apiVersion = "v" + apiVersionNumber
 		force.Credentials.ApiVersion = apiVersionNumber
-		ForceSaveLogin(force.Credentials)
+                ForceSaveLogin(*force.Credentials)
 	} else if len(args) == 0 {
 		fmt.Println(apiVersion)
 	} else {

--- a/force.go
+++ b/force.go
@@ -39,7 +39,7 @@ const (
 )*/
 
 type Force struct {
-        Credentials *ForceCredentials
+	Credentials *ForceCredentials
 	Metadata    *ForceMetadata
 	Partner     *ForcePartner
 }
@@ -56,8 +56,8 @@ type ForceCredentials struct {
 	ApiVersion    string
 	RefreshToken  string
 	ForceEndpoint ForceEndpoint
-        IsHourly      bool
-        HourlyCheck   bool
+	IsHourly      bool
+	HourlyCheck   bool
 }
 
 type LoginFault struct {
@@ -1211,46 +1211,46 @@ func (f *Force) RetrieveEventLogFile(elfId string) (result string, err error) {
 	return
 }
 
-func  (force *Force) setHourlyPerm() () {
-        force.Credentials.HourlyCheck = true
-        const EventLogFile string = "EventLogFile"
-        const HourlyEnabledField string = "Sequence"
-        force.Credentials.IsHourly = false
-        sobject, err := force.GetSobject(EventLogFile)
-        if err != nil {
-                ErrorAndExit(err.Error())
-        }
-        fields := ForceSobjectFields(sobject["fields"].([]interface{}))
-        for _, f := range fields {
-                field := f.(map[string]interface{})
-                if field["name"] == HourlyEnabledField {
-                      force.Credentials.IsHourly = true
-                      break
-                }
-        }
-        return
+func (force *Force) setHourlyPerm() {
+	force.Credentials.HourlyCheck = true
+	const EventLogFile string = "EventLogFile"
+	const HourlyEnabledField string = "Sequence"
+	force.Credentials.IsHourly = false
+	sobject, err := force.GetSobject(EventLogFile)
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+	fields := ForceSobjectFields(sobject["fields"].([]interface{}))
+	for _, f := range fields {
+		field := f.(map[string]interface{})
+		if field["name"] == HourlyEnabledField {
+			force.Credentials.IsHourly = true
+			break
+		}
+	}
+	return
 }
 
 func (f *Force) QueryEventLogFiles() (results ForceQueryResult, err error) {
-        if(!f.Credentials.HourlyCheck) {
-            f.setHourlyPerm()
-        }
-        url := ""
-        currApi, e := strconv.ParseFloat(f.Credentials.ApiVersion, 64)
-        if e != nil {
-                ErrorAndExit(e.Error())
-        }
-        if f.Credentials.IsHourly && currApi >= 37.0 {
-                url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength,+Sequence,+Interval+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType,+Sequence,+Interval", f.Credentials.InstanceUrl, apiVersion)
-        } else {
-                url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType", f.Credentials.InstanceUrl, apiVersion)
-        }
-        body, err := f.httpGet(url)
-        if err != nil {
-                return
-        }
-        json.Unmarshal(body, &results)
-        return
+	if !f.Credentials.HourlyCheck {
+		f.setHourlyPerm()
+	}
+	url := ""
+	currApi, e := strconv.ParseFloat(f.Credentials.ApiVersion, 64)
+	if e != nil {
+		ErrorAndExit(e.Error())
+	}
+	if f.Credentials.IsHourly && currApi >= 37.0 {
+		url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength,+Sequence,+Interval+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType,+Sequence,+Interval", f.Credentials.InstanceUrl, apiVersion)
+	} else {
+		url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType", f.Credentials.InstanceUrl, apiVersion)
+	}
+	body, err := f.httpGet(url)
+	if err != nil {
+		return
+	}
+	json.Unmarshal(body, &results)
+	return
 }
 
 func (f *Force) UpdateAuraComponent(source map[string]string, id string) (err error) {

--- a/force.go
+++ b/force.go
@@ -39,7 +39,7 @@ const (
 )*/
 
 type Force struct {
-	Credentials ForceCredentials
+        Credentials *ForceCredentials
 	Metadata    *ForceMetadata
 	Partner     *ForcePartner
 }
@@ -56,6 +56,7 @@ type ForceCredentials struct {
 	ApiVersion    string
 	RefreshToken  string
 	ForceEndpoint ForceEndpoint
+        IsHourly      bool
 }
 
 type LoginFault struct {
@@ -225,7 +226,7 @@ type BundleManifest struct {
 	Files []ComponentFile
 }
 
-func NewForce(creds ForceCredentials) (force *Force) {
+func NewForce(creds *ForceCredentials) (force *Force) {
 	force = new(Force)
 	force.Credentials = creds
 	force.Metadata = NewForceMetadata(force)
@@ -272,9 +273,8 @@ func ForceSoapLogin(endpoint ForceEndpoint, username string, password string) (c
 	}
 	instanceUrl := u.Scheme + "://" + u.Host
 	identity := u.Scheme + "://" + u.Host + "/id/" + orgid + "/" + result.Id
-	creds = ForceCredentials{AccessToken: result.SessionId, Id: identity, UserId: result.Id, InstanceUrl: instanceUrl, IsCustomEP: endpoint == EndpointCustom, ApiVersion: apiVersionNumber, ForceEndpoint: endpoint}
+	creds = ForceCredentials{AccessToken: result.SessionId, Id: identity, UserId: result.Id, InstanceUrl: instanceUrl, IsCustomEP: endpoint == EndpointCustom, ApiVersion: apiVersionNumber, ForceEndpoint: endpoint, IsHourly: false}
 	LogAuth()
-
 	return
 }
 
@@ -289,7 +289,7 @@ func (f *Force) UpdateCredentials(creds ForceCredentials) {
 	f.Credentials.InstanceUrl = creds.InstanceUrl
 	f.Credentials.Scope = creds.Scope
 	f.Credentials.Id = creds.Id
-	ForceSaveLogin(f.Credentials)
+	ForceSaveLogin(*f.Credentials)
 }
 
 func (f *Force) refreshTokenURL() string {
@@ -1210,14 +1210,42 @@ func (f *Force) RetrieveEventLogFile(elfId string) (result string, err error) {
 	return
 }
 
+func  (force *Force) setHourlyEnabled() () {
+        const EventLogFile string = "EventLogFile"
+        const HourlyEnabledField string = "Sequence"
+        force.Credentials.IsHourly = false
+        sobject, err := force.GetSobject(EventLogFile)
+        if err != nil {
+                ErrorAndExit(err.Error())
+        }
+        fields := ForceSobjectFields(sobject["fields"].([]interface{}))
+        for _, f := range fields {
+                field := f.(map[string]interface{})
+                if field["name"] == HourlyEnabledField {
+                      force.Credentials.IsHourly = true
+                      break
+                }
+        }
+        return
+}
+
 func (f *Force) QueryEventLogFiles() (results ForceQueryResult, err error) {
-	url := fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType", f.Credentials.InstanceUrl, apiVersion)
-	body, err := f.httpGet(url)
-	if err != nil {
-		return
-	}
-	json.Unmarshal(body, &results)
-	return
+        url := ""
+        currApi, e := strconv.ParseFloat(f.Credentials.ApiVersion, 64)
+        if e != nil {
+                ErrorAndExit(e.Error())
+        }
+        if f.Credentials.IsHourly && currApi >= 37.0 {
+                url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength,+Sequence,+Interval+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType,+Sequence,+Interval", f.Credentials.InstanceUrl, apiVersion)
+        } else {
+                url = fmt.Sprintf("%s/services/data/%s/query/?q=Select+Id,+LogDate,+EventType,+LogFileLength+FROM+EventLogFile+ORDER+BY+LogDate+DESC,+EventType", f.Credentials.InstanceUrl, apiVersion)
+        }
+        body, err := f.httpGet(url)
+        if err != nil {
+                return
+        }
+        json.Unmarshal(body, &results)
+        return
 }
 
 func (f *Force) UpdateAuraComponent(source map[string]string, id string) (err error) {

--- a/force.go
+++ b/force.go
@@ -57,6 +57,7 @@ type ForceCredentials struct {
 	RefreshToken  string
 	ForceEndpoint ForceEndpoint
         IsHourly      bool
+        HourlyCheck   bool
 }
 
 type LoginFault struct {
@@ -273,7 +274,7 @@ func ForceSoapLogin(endpoint ForceEndpoint, username string, password string) (c
 	}
 	instanceUrl := u.Scheme + "://" + u.Host
 	identity := u.Scheme + "://" + u.Host + "/id/" + orgid + "/" + result.Id
-	creds = ForceCredentials{AccessToken: result.SessionId, Id: identity, UserId: result.Id, InstanceUrl: instanceUrl, IsCustomEP: endpoint == EndpointCustom, ApiVersion: apiVersionNumber, ForceEndpoint: endpoint, IsHourly: false}
+	creds = ForceCredentials{AccessToken: result.SessionId, Id: identity, UserId: result.Id, InstanceUrl: instanceUrl, IsCustomEP: endpoint == EndpointCustom, ApiVersion: apiVersionNumber, ForceEndpoint: endpoint, IsHourly: false, HourlyCheck: false}
 	LogAuth()
 	return
 }
@@ -1210,7 +1211,8 @@ func (f *Force) RetrieveEventLogFile(elfId string) (result string, err error) {
 	return
 }
 
-func  (force *Force) setHourlyEnabled() () {
+func  (force *Force) setHourlyPerm() () {
+        force.Credentials.HourlyCheck = true
         const EventLogFile string = "EventLogFile"
         const HourlyEnabledField string = "Sequence"
         force.Credentials.IsHourly = false
@@ -1230,6 +1232,9 @@ func  (force *Force) setHourlyEnabled() () {
 }
 
 func (f *Force) QueryEventLogFiles() (results ForceQueryResult, err error) {
+        if(!f.Credentials.HourlyCheck) {
+            f.setHourlyPerm()
+        }
         url := ""
         currApi, e := strconv.ParseFloat(f.Credentials.ApiVersion, 64)
         if e != nil {

--- a/login.go
+++ b/login.go
@@ -116,7 +116,8 @@ func CurrentEndpoint() (endpoint ForceEndpoint, customUrl string, err error) {
 }
 
 func ForceSaveLogin(creds ForceCredentials) (username string, err error) {
-	force := NewForce(creds)
+        force := NewForce(&creds)
+        force.setHourlyEnabled();
 	login, err := force.Get(creds.Id)
 	if err != nil {
 		return

--- a/login.go
+++ b/login.go
@@ -117,7 +117,6 @@ func CurrentEndpoint() (endpoint ForceEndpoint, customUrl string, err error) {
 
 func ForceSaveLogin(creds ForceCredentials) (username string, err error) {
         force := NewForce(&creds)
-        force.setHourlyEnabled();
 	login, err := force.Get(creds.Id)
 	if err != nil {
 		return

--- a/login.go
+++ b/login.go
@@ -116,7 +116,7 @@ func CurrentEndpoint() (endpoint ForceEndpoint, customUrl string, err error) {
 }
 
 func ForceSaveLogin(creds ForceCredentials) (username string, err error) {
-        force := NewForce(&creds)
+	force := NewForce(&creds)
 	login, err := force.Get(creds.Id)
 	if err != nil {
 		return

--- a/logins.go
+++ b/logins.go
@@ -86,7 +86,7 @@ func ActiveForce() (force *Force, err error) {
 	if err != nil {
 		return
 	}
-        force = NewForce(&creds)
+	force = NewForce(&creds)
 	return
 }
 

--- a/logins.go
+++ b/logins.go
@@ -86,7 +86,7 @@ func ActiveForce() (force *Force, err error) {
 	if err != nil {
 		return
 	}
-	force = NewForce(creds)
+        force = NewForce(&creds)
 	return
 }
 


### PR DESCRIPTION
https://gus.my.salesforce.com/apex/adm_userstorydetail?id=a07B000000222TQIAY&sfdc.override=1
We now have hourly event log files and daily event log files. We now check for hourly permissions at login. When users query event log files, we display the hourly event log files along with additional headers (sequence and interval) if they have hourly turned on. If not, we display only daily event log files.