### PR TITLE
Default query format to csv for non-tty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 - go get github.com/kr/binarydist
 - go get github.com/kr/pretty
 - go get github.com/kr/text
+- go get golang.org/x/crypto/ssh/terminal
 script:
 - git config --global user.email "you@example.com"
 - git config --global user.name "Your Name"

--- a/query.go
+++ b/query.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"golang.org/x/crypto/ssh/terminal"
+	"os"
 	"strings"
 )
 
@@ -28,6 +30,9 @@ func runQuery(cmd *Command, args []string) {
 		cmd.printUsage()
 	} else {
 		format := "console"
+		if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+			format = "csv"
+		}
 		var formatArg = ""
 		var isTooling = false
 		var formatIndex = 1


### PR DESCRIPTION
Set the default formatting for query output to csv when printing to a
non-tty device.

The default "console" format is not overly machine-friendly, and it's
typical to print a more parsable output when the output device is
determined to not be a tty device.  For example, ls(1) defaults to the
"-1" option when the output device is nontty.

Supplying  the '--format:' argument will override the default behavior.