### PR TITLE
[#143] Fix NPE in whoami

### DIFF
--- a/logins.go
+++ b/logins.go
@@ -68,11 +68,14 @@ func ActiveLogin() (account string, err error) {
 
 func ActiveCredentials(requireCredentials bool) (creds ForceCredentials, err error) {
 	account, err := ActiveLogin()
-	if err != nil && requireCredentials {
+	if requireCredentials && (err != nil || strings.TrimSpace(account) == "") {
 		ErrorAndExit("Please login before running this command.")
 	}
-	data, err := Config.Load("accounts", account)
-	json.Unmarshal([]byte(data), &creds)
+	data, err := Config.Load("accounts", strings.TrimSpace(account))
+	if requireCredentials && err != nil {
+		ErrorAndExit("Failed to load credentials. %v", err)
+	}
+	_ = json.Unmarshal([]byte(data), &creds)
 	if creds.ApiVersion != "" {
 		apiVersionNumber = creds.ApiVersion
 		apiVersion = "v" + apiVersionNumber

--- a/logins_test.go
+++ b/logins_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/bmizerany/assert"
 	"github.com/devangel/config"
+	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -10,7 +12,35 @@ var TestConfig = config.NewConfig("force")
 
 // test that SetActiveLogin in turn sets the "current account"
 func TestSetActiveLogin(t *testing.T) {
+	prevAcct, err := TestConfig.Load("current", "account")
+	if err != nil {
+		prevAcct = ""
+	}
 	SetActiveLogin("clint")
 	account, _ := TestConfig.Load("current", "account")
+	SetActiveLogin(prevAcct)
 	assert.Equal(t, account, "clint")
+}
+
+/* test that ActiveCredentials exits with a status code of 1 if there is no matching
+ * credential file for the active login.
+ */
+func TestActiveCredentialsMissingFile(t *testing.T) {
+	if os.Getenv("TEST_MISSING_CREDS") == "1" {
+		SetActiveLogin("no_matching_credentials_file")
+		ActiveCredentials(true)
+		return
+	}
+	prevAcct, err := TestConfig.Load("current", "account")
+	if err != nil {
+		prevAcct = ""
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestActiveCredentialsMissingFile")
+	cmd.Env = append(os.Environ(), "TEST_MISSING_CREDS=1")
+	err = cmd.Run()
+	SetActiveLogin(prevAcct)
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, expect exit status 1", err)
 }


### PR DESCRIPTION
This fixes issue #143 .

To replicate the issue:

$ echo foobar > ~/.force/current/account; force whoami

Fix an issue with `force whoami` where it would encounter a nil pointer
dereference when the active account didn't have a matching file under
the ~/.force/accounts directory.

Also improved the tests so that it preserves the current active login.