### PR TITLE
force push src/classes/Source_File.cls-meta.xml

### DIFF
--- a/packagebuilder.go
+++ b/packagebuilder.go
@@ -123,6 +123,20 @@ func (pb *PackageBuilder) ForceMetadataFiles() ForceMetadataFiles {
 	return pb.Files
 }
 
+// Returns the source file path for a given metadata file path.
+func MetaPathToSourcePath(mpath string) (spath string) {
+	spath = strings.TrimSuffix(mpath, "-meta.xml")
+	if spath == mpath {
+		return
+	}
+
+	_, err := os.Stat(spath)
+	if err != nil {
+		spath = mpath
+	}
+	return
+}
+
 // Add a file to the builder
 func (pb *PackageBuilder) AddFile(fpath string) (fname string, err error) {
 	fpath, err = filepath.Abs(fpath)
@@ -139,6 +153,7 @@ func (pb *PackageBuilder) AddFile(fpath string) (fname string, err error) {
 		return
 	}
 
+	fpath = MetaPathToSourcePath(fpath)
 	metaName, fname := getMetaTypeFromPath(fpath)
 	if !isDestructiveChanges && !strings.HasSuffix(fpath, "-meta.xml") {
 		pb.AddMetaToPackage(metaName, fname)

--- a/packagebuilder_test.go
+++ b/packagebuilder_test.go
@@ -75,6 +75,28 @@ var _ = Describe("Packagebuilder", func() {
 			})
 		})
 
+		Context("when adding both a metadata file and a meta.xml file", func() {
+			var apexClassPath string
+			var apexClassMetadataPath string
+
+			BeforeEach(func() {
+				os.MkdirAll(tempDir+"/src/classes", 0755)
+				apexClassPath = tempDir + "/src/classes/Test.cls"
+				apexClassContents := "class Test {}"
+				ioutil.WriteFile(apexClassPath, []byte(apexClassContents), 0644)
+				apexClassMetadataPath = tempDir + "/src/classes/Test.cls-meta.xml"
+				apexClassMetadataContents := `<?xml version="1.0" encoding="UTF-8"?>`
+				ioutil.WriteFile(apexClassMetadataPath, []byte(apexClassMetadataContents), 0644)
+			})
+
+			It("should add both files to package", func() {
+				_, err := pb.AddFile(apexClassMetadataPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pb.Files).To(HaveKey("classes/Test.cls"))
+				Expect(pb.Files).To(HaveKey("classes/Test.cls-meta.xml"))
+			})
+		})
+
 		Context("when adding a CustomMetadata file", func() {
 			var customMetadataPath string
 


### PR DESCRIPTION
This patch allows users to "force push" a metadata file and have it
package up the associated source file as well. Before, if the user
just tried to push metadata only, say to bump the API version of a
file, they would get this error:

    Error: Must specify both the source file & the metadata file