### PR TITLE
Exit With Error When Push Fails

### DIFF
--- a/push.go
+++ b/push.go
@@ -469,7 +469,10 @@ func deployPackage() {
 	for _, name := range resourcepaths {
 		zipfile, err := ioutil.ReadFile(name)
 		result, err := force.Metadata.DeployZipFile(force.Metadata.MakeDeploySoap(*DeploymentOptions), zipfile)
-		processDeployResults(result, err)
+		err = processDeployResults(result, err)
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
 	}
 	return
 }
@@ -478,7 +481,10 @@ func deployFiles(files ForceMetadataFiles) {
 	force, _ := ActiveForce()
 	var DeploymentOptions = deployOpts()
 	result, err := force.Metadata.Deploy(files, *DeploymentOptions)
-	processDeployResults(result, err)
+	err = processDeployResults(result, err)
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
 	return
 }
 
@@ -499,9 +505,9 @@ func deployOpts() *ForceDeployOptions {
 }
 
 // Process and display the result of the push operation
-func processDeployResults(result ForceCheckDeploymentStatusResult, err error) {
-	if err != nil {
-		ErrorAndExit(err.Error())
+func processDeployResults(result ForceCheckDeploymentStatusResult, deployErr error) (err error) {
+	if deployErr != nil {
+		ErrorAndExit(deployErr.Error())
 	}
 
 	problems := result.Details.ComponentFailures
@@ -558,4 +564,10 @@ func processDeployResults(result ForceCheckDeploymentStatusResult, err error) {
 
 	// Handle notifications
 	notifySuccess("push", len(problems) == 0)
+	if len(problems) > 0 {
+		err = errors.New("Some components failed deployment")
+	} else if len(testFailures) > 0 {
+		err = errors.New("Some tests failed")
+	}
+	return
 }


### PR DESCRIPTION
Exit with an error status when an error occurs running `force push`.