### PR TITLE
Allow Setting of Concurrency Mode for Bulk Operations

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -248,9 +248,11 @@ func handleDML(args []string) {
 	} else {
 		objectType = args[1]
 		file := args[2]
-		if argLength == 4 || argLength == 5 {
+		if argLength == 4 {
 			setConcurrencyModeOrFileFormat(args[3])
-			setConcurrencyModeOrFileFormat(args[4])
+			if argLength == 5 {
+				setConcurrencyModeOrFileFormat(args[4])
+			}
 		}
 		runDBCommand(file)
 	}

--- a/bulk.go
+++ b/bulk.go
@@ -126,8 +126,8 @@ func init() {
 	cmdBulk.Flag.StringVar(&fileFormat, "f", "CSV", "File format.")
 	cmdBulk.Flag.StringVar(&externalId, "externalId", "", "The external Id field for upserts of data.")
 	cmdBulk.Flag.StringVar(&externalId, "e", "", "The External Id Field for upserts of data.")
-  cmdBulk.Flag.StringVar(&concurrencyMode, "m", "", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
-  cmdBulk.Flag.StringVar(&concurrencyMode, "concurrencyMode", "", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
+	cmdBulk.Flag.StringVar(&concurrencyMode, "m", "", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
+	cmdBulk.Flag.StringVar(&concurrencyMode, "concurrencyMode", "", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
 	cmdBulk.Run = runBulk
 }
 
@@ -518,7 +518,7 @@ func createBulkJob(objectType string, operation string, fileFormat string, exter
 		xml += `<concurrencyMode>Serial</concurrencyMode>`
 	}
 
-  xml += `<contentType>%s</contentType>
+	xml += `<contentType>%s</contentType>
 	</jobInfo>
 	`
 

--- a/bulk.go
+++ b/bulk.go
@@ -513,12 +513,14 @@ func createBulkJob(objectType string, operation string, fileFormat string, exter
  		<operation>%s</operation>
  		<object>%s</object>
  		`
-	if operation == "upsert" {
-		xml += `<externalIdFieldName>upsert</externalIdFieldName>`
+	if strings.EqualFold(concurrencyMode, "serial") {
+		xml += `<concurrencyMode>Serial</concurrencyMode>
+		`
 	}
 
-	if strings.EqualFold(concurrencyMode, "serial") {
-		xml += `<concurrencyMode>Serial</concurrencyMode>`
+	if operation == "upsert" {
+		xml += `<externalIdFieldName>%s</externalIdFieldName>
+		`
 	}
 
 	xml += `<contentType>%s</contentType>
@@ -526,7 +528,11 @@ func createBulkJob(objectType string, operation string, fileFormat string, exter
 	`
 
 	data := ""
-	data = fmt.Sprintf(xml, objectType, fileFormat)
+	if operation == "upsert" {
+		data = fmt.Sprintf(xml, operation, objectType, externalId, fileFormat)
+	} else {
+		data = fmt.Sprintf(xml, operation, objectType, fileFormat)
+	}
 	jobInfo, err = force.CreateBulkJob(data)
 	return
 }

--- a/bulk.go
+++ b/bulk.go
@@ -126,8 +126,8 @@ func init() {
 	cmdBulk.Flag.StringVar(&fileFormat, "f", "CSV", "File format.")
 	cmdBulk.Flag.StringVar(&externalId, "externalId", "", "The external Id field for upserts of data.")
 	cmdBulk.Flag.StringVar(&externalId, "e", "", "The External Id Field for upserts of data.")
-	cmdBulk.Flag.StringVar(&concurrencyMode, "m", "", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
-	cmdBulk.Flag.StringVar(&concurrencyMode, "concurrencyMode", "", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
+	cmdBulk.Flag.StringVar(&concurrencyMode, "m", "Parallel", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
+	cmdBulk.Flag.StringVar(&concurrencyMode, "concurrencyMode", "Parallel", "Concurrency mode for bulk api inserts, updates and upserts.  Valid options are `Serial` and `Parallel` (default).")
 	cmdBulk.Run = runBulk
 }
 

--- a/bulk.go
+++ b/bulk.go
@@ -109,7 +109,7 @@ var (
 	batchId         string
 	fileFormat      string
 	externalId      string
-  concurrencyMode string
+	concurrencyMode string
 )
 var commandVersion = "old"
 
@@ -235,23 +235,23 @@ func handleInfo(args []string) {
 }
 
 func handleDML(args []string) {
-  var argLength = len(args)
-  if args[0] == "upsert" {
-    externalId = args[1]
-    objectType = args[2]
-    file := args[3]
-    if argLength == 5 || argLength == 6 {
-      setConcurrencyModeOrFileFormat(args[4])
-      setConcurrencyModeOrFileFormat(args[5])
-    }
-  } else {
-    objectType = args[1]
-    file := args[2]
-    if argLength == 4 || argLength == 5 {
-      setConcurrencyModeOrFileFormat(args[3])
-      setConcurrencyModeOrFileFormat(args[4])
-    }
-  }
+	var argLength = len(args)
+	if args[0] == "upsert" {
+		externalId = args[1]
+		objectType = args[2]
+		file := args[3]
+		if argLength == 5 || argLength == 6 {
+			setConcurrencyModeOrFileFormat(args[4])
+			setConcurrencyModeOrFileFormat(args[5])
+		}
+	} else {
+		objectType = args[1]
+		file := args[2]
+		if argLength == 4 || argLength == 5 {
+			setConcurrencyModeOrFileFormat(args[3])
+			setConcurrencyModeOrFileFormat(args[4])
+		}
+	}
 	runDBCommand(file)
 }
 
@@ -270,11 +270,11 @@ func handleQuery(args []string) {
 }
 
 func setConcurrencyModeOrFileFormat(argument string) {
-  if strings.EqualFold(argument, "parallel") || strings.EqualFold(argument, "serial") {
-    concurrencyMode = argument
-  } else {
-    fileFormat = argument
-  }
+	if strings.EqualFold(argument, "parallel") || strings.EqualFold(argument, "serial") {
+		concurrencyMode = argument
+	} else {
+		fileFormat = argument
+	}
 }
 
 func doBulkQuery(objectType string, soql string, contenttype string, concurrencyMode string) {
@@ -497,6 +497,12 @@ func getBatchInfo(jobId string, batchId string) (batchInfo BatchInfo, err error)
 }
 
 func createBulkJob(objectType string, operation string, fileFormat string, externalId string, concurrencyMode string) (jobInfo JobInfo, err error) {
+	if not strings.EqualFold(concurrencyMode, "serial") {
+		if not strings.EqualFold(concurrencyMode, "parallel") {
+			ErrorAndExit("Concurrency Mode must be set to either Serial or Parallel")
+		}
+	}
+
 	force, _ := ActiveForce()
 
 	xml := `
@@ -508,16 +514,16 @@ func createBulkJob(objectType string, operation string, fileFormat string, exter
 		xml += `<externalIdFieldName>upsert</externalIdFieldName>`
 	}
 
-  if strings.EqualFold(concurrencyMode, "serial") {
-    xml += `<concurrencyMode>Serial</concurrencyMode>`
-  }
+	if strings.EqualFold(concurrencyMode, "serial") {
+		xml += `<concurrencyMode>Serial</concurrencyMode>`
+	}
 
   xml += `<contentType>%s</contentType>
 	</jobInfo>
 	`
 
 	data := ""
-  data = fmt.Sprintf(xml, objectType, fileFormat)
+	data = fmt.Sprintf(xml, objectType, fileFormat)
 	jobInfo, err = force.CreateBulkJob(data)
 	return
 }

--- a/bulk.go
+++ b/bulk.go
@@ -89,9 +89,9 @@ Examples using flags - more flexible, flags can be in any order with arguments a
 
 Examples using positional arguments - less flexible, arguments must be in the correct order.
 
-  force bulk insert Account [csv file] [concurrency mode (optional)]
-  force bulk update Account [csv file] [concurrency mode (optional)]
-  force bulk upsert ExternalIdField__c Account [csv file] [concurrency mode (optional)]
+  force bulk insert Account [csv file] [<concurrency mode>]
+  force bulk update Account [csv file] [<concurrency mode>]
+  force bulk upsert ExternalIdField__c Account [csv file] [<concurrency mode>]
   force bulk job [job id]
   force bulk batches [job id]
   force Bulk batch [job id] [batch id]
@@ -244,6 +244,7 @@ func handleDML(args []string) {
 			setConcurrencyModeOrFileFormat(args[4])
 			setConcurrencyModeOrFileFormat(args[5])
 		}
+		runDBCommand(file)
 	} else {
 		objectType = args[1]
 		file := args[2]
@@ -251,8 +252,8 @@ func handleDML(args []string) {
 			setConcurrencyModeOrFileFormat(args[3])
 			setConcurrencyModeOrFileFormat(args[4])
 		}
+		runDBCommand(file)
 	}
-	runDBCommand(file)
 }
 
 func handleQuery(args []string) {
@@ -497,8 +498,8 @@ func getBatchInfo(jobId string, batchId string) (batchInfo BatchInfo, err error)
 }
 
 func createBulkJob(objectType string, operation string, fileFormat string, externalId string, concurrencyMode string) (jobInfo JobInfo, err error) {
-	if not strings.EqualFold(concurrencyMode, "serial") {
-		if not strings.EqualFold(concurrencyMode, "parallel") {
+	if !(strings.EqualFold(concurrencyMode, "serial")) {
+		if !(strings.EqualFold(concurrencyMode, "parallel")) {
 			ErrorAndExit("Concurrency Mode must be set to either Serial or Parallel")
 		}
 	}

--- a/record.go
+++ b/record.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 )
 
 var cmdRecord = &Command{
@@ -19,7 +20,7 @@ Usage:
 
   force record create <object> [<fields>]
 
-  force record create:bulk <object> <file> [<format>]
+  force record create:bulk <object> <file> [<format>] [<concurrency mode>]
 
   force record update <object> <id> [<fields>]
 
@@ -54,9 +55,19 @@ func runRecord(cmd *Command, args []string) {
 			runRecordCreate(args[1:])
 		case "create:bulk":
 			if len(args) == 3 {
-				createBulkInsertJob(args[2], args[1], "CSV")
+				createBulkInsertJob(args[2], args[1], "CSV", "Parallel")
 			} else if len(args) == 4 {
-				createBulkInsertJob(args[2], args[1], args[3])
+				if strings.EqualFold(args[3], "parallel") || strings.EqualFold(args[3], "serial") {
+					createBulkInsertJob(args[2], args[1], "CSV", args[3])
+				} else {
+					createBulkInsertJob(args[2], args[1], args[3], "Parallel")
+				}
+			} else if len(args) == 5 {
+				if strings.EqualFold(args[3], "parallel") || strings.EqualFold(args[3], "serial") {
+					createBulkInsertJob(args[2], args[1], args[4], args[3])
+				} else if strings.EqualFold(args[4], "parallel") || strings.EqualFold(args[4], "serial") {
+					createBulkInsertJob(args[2], args[1], args[3], args[4])
+				}
 			}
 		case "update":
 			runRecordUpdate(args[1:])


### PR DESCRIPTION
This PR allows the Concurrency Mode to be set (the default, Parallel, or Serial) for force.com Bulk OPs in either the flag or ordered command format.

It handles the undocumented file type option for the ordered format as well as the new option without breakage.

Additionally, it adds upsert operations to the ordered command format.