### PR TITLE
Fix wrong field name of metadata

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -343,7 +343,7 @@ type MDFileProperties struct {
 	Id                 string    `xml:"id"`
 	LastModifiedById   string    `xml:"lastModifiedById"`
 	LastModifiedByName string    `xml:"lastModifiedByName"`
-	LastModifedByDate  time.Time `xml:"lastModifiedByDate"`
+	LastModifedDate    time.Time `xml:"lastModifiedDate"`
 	ManageableState    string    `xml:"manageableState"`
 	NamespacePrefix    string    `xml:"namespacePrefix"`
 	Type               string    `xml:"type"`


### PR DESCRIPTION
LastModifedByDate is wrong field name.
So fix to the correct name.

Issue #389.