### PR TITLE
`force push` respects `force apiversion`

### DIFF
--- a/apiversion.go
+++ b/apiversion.go
@@ -25,18 +25,21 @@ Examples:
 func init() {
 }
 
+func parseApiVersion(args []string) {
+	matcher := regexp.MustCompile(`^v?(\d+\.0)$`)
+	matched := matcher.FindStringSubmatch(args[0])
+	if matched == nil {
+		ErrorAndExit("apiversion must be in the form of nn.0.")
+	}
+
+	apiVersionNumber = matched[1]
+	apiVersion = fmt.Sprintf("v%s", apiVersionNumber)
+}
+
 func runApiVersion(cmd *Command, args []string) {
 	force, _ := ActiveForce()
 	if len(args) == 1 {
-		apiVersionNumber = args[0]
-		matched, err := regexp.MatchString("^\\d{2}\\.0$", apiVersionNumber)
-		if err != nil {
-			ErrorAndExit("%v", err)
-		}
-		if !matched {
-			ErrorAndExit("apiversion must be in the form of nn.0.")
-		}
-		apiVersion = fmt.Sprintf("v%s", apiVersionNumber)
+		parseApiVersion(args)
 		force.Credentials.ApiVersion = apiVersionNumber
 		ForceSaveLogin(*force.Credentials)
 	} else if len(args) == 0 {

--- a/apiversion_test.go
+++ b/apiversion_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseApiVersion(t *testing.T) {
+	// Bare version number
+	parseApiVersion([]string{"1.0"})
+	if apiVersionNumber != "1.0" {
+		t.Errorf("apiVersionNumber = %v, want 1.0", apiVersionNumber)
+	}
+	if apiVersion != "v1.0" {
+		t.Errorf("apiVersion = %v, want v1.0", apiVersion)
+	}
+
+	// With v-prefix
+	parseApiVersion([]string{"v2.0"})
+	if apiVersionNumber != "2.0" {
+		t.Errorf("apiVersionNumber = %v, want 2.0", apiVersionNumber)
+	}
+	if apiVersion != "v2.0" {
+		t.Errorf("apiVersion = %v, want v2.0", apiVersion)
+	}
+}

--- a/force.go
+++ b/force.go
@@ -35,11 +35,6 @@ const (
 	EndpointCustom     = iota
 )
 
-/*const (
-	apiVersion       = "v34.0"
-	apiVersionNumber = "34.0"
-)*/
-
 type Force struct {
 	Credentials *ForceCredentials
 	Metadata    *ForceMetadata

--- a/metadata.go
+++ b/metadata.go
@@ -1192,7 +1192,7 @@ func (fm *ForceMetadata) DeployWithTempFile(soap string, filename string) {
 	os.MkdirAll(tempdir, 0777)
 	xmlfile := filepath.Join(tempdir, filename)
 	ioutil.WriteFile(xmlfile, []byte(soap), 0777)
-	pushByPaths([]string{xmlfile})
+	pushByPaths(fm.Force, []string{xmlfile})
 }
 
 func (fm *ForceMetadata) Deploy(files ForceMetadataFiles, options ForceDeployOptions) (results ForceCheckDeploymentStatusResult, err error) {

--- a/packagebuilder.go
+++ b/packagebuilder.go
@@ -23,7 +23,7 @@ type MetaType struct {
 
 func createPackage() Package {
 	return Package{
-		Version: strings.TrimPrefix(apiVersion, "v"),
+		Version: apiVersionNumber,
 		Xmlns:   "http://soap.sforce.com/2006/04/metadata",
 	}
 }


### PR DESCRIPTION
In #410, we worked around the fact that `force push` ignores `force apiversion` by hardcoding the "39.0".

The reason why this had to be done is that `runPush()` didn't actually call `ActiveForce()` early enough, so `createPackage()` was never using the actual API version from our credentials.