### PR TITLE
Write session token refresh message to stderr

### DIFF
--- a/apiversion.go
+++ b/apiversion.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 )
 
@@ -38,7 +39,7 @@ func runApiVersion(cmd *Command, args []string) {
 		}
 		apiVersion = fmt.Sprintf("v%s", apiVersionNumber)
 		force.Credentials.ApiVersion = apiVersionNumber
-		ForceSaveLogin(*force.Credentials)
+		ForceSaveLogin(*force.Credentials, os.Stdout)
 	} else if len(args) == 0 {
 		fmt.Println(apiVersion)
 	} else {

--- a/force.go
+++ b/force.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -296,7 +297,7 @@ func (f *Force) UpdateCredentials(creds ForceCredentials) {
 	f.Credentials.InstanceUrl = creds.InstanceUrl
 	f.Credentials.Scope = creds.Scope
 	f.Credentials.Id = creds.Id
-	ForceSaveLogin(*f.Credentials)
+	ForceSaveLogin(*f.Credentials, os.Stderr)
 }
 
 func (f *Force) refreshTokenURL() string {
@@ -330,7 +331,7 @@ func (f *Force) RefreshSession() (err error, emessages []ForceError) {
 		return
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	fmt.Println("Refreshing Session Token")
+	fmt.Fprintln(os.Stderr, "Refreshing Session Token")
 	res, err := doRequest(req)
 	if err != nil {
 		return


### PR DESCRIPTION
(Or stdout, but only when appropriate.)

This allows the utility output to be piped into other processes without first filtering for messages.