### PR TITLE
Fix OAuth Token Refresh

### DIFF
--- a/force.go
+++ b/force.go
@@ -322,7 +322,7 @@ func (f *Force) refreshTokenURL() string {
 
 func (f *Force) RefreshSession() (err error, emessages []ForceError) {
 	attrs := url.Values{}
-	attrs.Set("grant_type", "refresh_token api web")
+	attrs.Set("grant_type", "refresh_token")
 	attrs.Set("refresh_token", f.Credentials.RefreshToken)
 	attrs.Set("client_id", ClientId)
 	attrs.Set("format", "json")


### PR DESCRIPTION
Revert change to grant_type parameter when refreshing an OAuth token.
Per the documentation (http://sforce.co/2f0d9HL), grant_type must be
refresh_token.  Including api and web in the grant_type breaks use of a
refresh token to get a new session token.