### PR TITLE
Add Session Refresh for SOAP and SFDX

### DIFF
--- a/command/active.go
+++ b/command/active.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -39,14 +38,14 @@ func init() {
 
 func runActive(cmd *Command, args []string) {
 	if account == "" {
-		account, _ := Config.Load("current", "account")
-		data, _ := Config.Load("accounts", account)
-		var creds ForceCredentials
-		json.Unmarshal([]byte(data), &creds)
+		creds, err := ActiveCredentials(true)
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
 		if tojson {
-			fmt.Printf(fmt.Sprintf("{ \"login\": \"%s\", \"instanceUrl\": \"%s\", \"namespace\":\"%s\" }", account, creds.InstanceUrl, creds.Namespace))
+			fmt.Printf(fmt.Sprintf("{ \"login\": \"%s\", \"instanceUrl\": \"%s\", \"namespace\":\"%s\" }", creds.SessionName(), creds.InstanceUrl, creds.UserInfo.OrgNamespace))
 		} else {
-			fmt.Println(fmt.Sprintf("%s - %s - ns:%s", account, creds.InstanceUrl, creds.Namespace))
+			fmt.Println(fmt.Sprintf("%s - %s - ns:%s", creds.SessionName(), creds.InstanceUrl, creds.UserInfo.OrgNamespace))
 		}
 	} else {
 		//account := args[0]

--- a/command/apiversion.go
+++ b/command/apiversion.go
@@ -35,7 +35,14 @@ func runApiVersion(cmd *Command, args []string) {
 		if !matched {
 			ErrorAndExit("apiversion must be in the form of nn.0.")
 		}
-		UpdateApiVersion(apiVersionNumber)
+		force, err := ActiveForce()
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+		err = force.UpdateApiVersion(apiVersionNumber)
+		if err != nil {
+			ErrorAndExit("%v", err)
+		}
 	} else if len(args) == 0 {
 		fmt.Println(ApiVersion())
 	} else {

--- a/command/logins.go
+++ b/command/logins.go
@@ -35,7 +35,7 @@ func runLogins(cmd *Command, args []string) {
 
 		for _, account := range accounts {
 			if !strings.HasPrefix(account, ".") {
-				var creds ForceCredentials
+				var creds ForceSession
 				data, err := Config.Load("accounts", account)
 				json.Unmarshal([]byte(data), &creds)
 

--- a/command/rest.go
+++ b/command/rest.go
@@ -2,11 +2,11 @@ package command
 
 import (
 	"fmt"
-	"strings"
 	"io/ioutil"
+	"strings"
 
+	. "github.com/heroku/force/error"
 	. "github.com/heroku/force/lib"
-	. "github.com/heroku/force/error"	
 )
 
 var cmdRest = &Command{
@@ -36,7 +36,7 @@ func runRest(cmd *Command, args []string) {
 		// and handle other than get
 		var (
 			data = ""
-			msg = ""
+			msg  = ""
 		)
 		var err error
 		if strings.ToLower(args[0]) == "get" {

--- a/lib/apiversion.go
+++ b/lib/apiversion.go
@@ -16,12 +16,11 @@ func ApiVersionNumber() string {
 	return apiVersionNumber
 }
 
-func UpdateApiVersion(version string) {
-	apiVersion = "v" + version
-	apiVersionNumber = version
-	force, _ := ActiveForce()
-	force.Credentials.ApiVersion = apiVersionNumber
-	ForceSaveLogin(*force.Credentials, os.Stdout)
+func (f *Force) UpdateApiVersion(version string) (err error) {
+	SetApiVersion(version)
+	f.Credentials.SessionOptions.ApiVersion = version
+	_, err = ForceSaveLogin(*f.Credentials, os.Stdout)
+	return
 }
 
 func SetApiVersion(version string) {

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -1425,18 +1425,12 @@ func (fm *ForceMetadata) ListConnectedApps() (apps ForceConnectedApps, err error
 }
 
 func (fm *ForceMetadata) soapExecute(action, query string) (response []byte, err error) {
-	url := ""
-	if len(fm.Force.Credentials.Id) > 0 {
-		login, err1 := fm.Force.Get(fm.Force.Credentials.Id)
-		if err1 != nil {
-			err = err1
-			return
-		}
-		url = strings.Replace(login["urls"].(map[string]interface{})["metadata"].(string), "{version}", fm.ApiVersion, 1)
-	} else {
-		url = fmt.Sprintf("%s/%s/%s", fm.Force.Credentials.InstanceUrl, "services/Soap/m", fm.ApiVersion)//, "/00DB00000000lWZ"
-	}
+	url := fmt.Sprintf("%s/services/Soap/m/%s", fm.Force.Credentials.InstanceUrl, fm.ApiVersion)
 	soap := NewSoap(url, "http://soap.sforce.com/2006/04/metadata", fm.Force.Credentials.AccessToken)
 	response, err = soap.Execute(action, query)
+	if err == SessionExpiredError {
+		fm.Force.RefreshSessionOrExit()
+		return fm.soapExecute(action, query)
+	}
 	return
 }

--- a/lib/session.go
+++ b/lib/session.go
@@ -1,0 +1,79 @@
+package lib
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	. "github.com/heroku/force/error"
+	"io/ioutil"
+	"net/url"
+	"os"
+)
+
+func (f *Force) refreshOauth() (err error) {
+	attrs := url.Values{}
+	attrs.Set("grant_type", "refresh_token")
+	attrs.Set("refresh_token", f.Credentials.RefreshToken)
+	attrs.Set("client_id", ClientId)
+	attrs.Set("format", "json")
+
+	postVars := attrs.Encode()
+	req, err := httpRequest("POST", f.refreshTokenURL(), bytes.NewReader([]byte(postVars)))
+	if err != nil {
+		return
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	fmt.Fprintln(os.Stderr, "Refreshing Session Token")
+	res, err := doRequest(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if res.StatusCode != 200 {
+		err = errors.New("Failed to refresh session.  Please run `force login`.")
+		return
+	}
+	if err != nil {
+		return
+	}
+
+	var result ForceSession
+	json.Unmarshal(body, &result)
+	f.UpdateCredentials(result)
+	return
+}
+
+func (f *Force) refreshSFDX() (err error) {
+	fmt.Fprintln(os.Stderr, "Refreshing Session Token Using SFDX")
+	sfdxAuth, err := GetSFDXAuth(f.Credentials.UserInfo.UserName)
+	if err != nil {
+		return
+	}
+	newCreds := ForceSession{
+		AccessToken: sfdxAuth.AccessToken,
+		InstanceUrl: sfdxAuth.InstanceUrl,
+	}
+	f.UpdateCredentials(newCreds)
+	return
+}
+
+func (f *Force) RefreshSessionOrExit() {
+	err := f.RefreshSession()
+	if err != nil {
+		ErrorAndExit(err.Error())
+	}
+}
+
+func (f *Force) RefreshSession() (err error) {
+	if f.Credentials.SessionOptions.RefreshMethod == RefreshOauth {
+		err = f.refreshOauth()
+	} else if f.Credentials.SessionOptions.RefreshMethod == RefreshSFDX {
+		err = f.refreshSFDX()
+	} else {
+		err = errors.New("Unable to refresh.  Please run `force login`.")
+	}
+	return
+}

--- a/lib/sfdx.go
+++ b/lib/sfdx.go
@@ -1,0 +1,68 @@
+package lib
+
+import (
+	"encoding/json"
+	"fmt"
+	. "github.com/heroku/force/error"
+	"os"
+	"os/exec"
+)
+
+type SFDXAuth struct {
+	AccessToken string
+	Alias       string
+	ClientId    string
+	CreatedBy   string
+	DevHubId    string
+	Edition     string
+	Id          string
+	InstanceUrl string
+	OrgName     string
+	Password    string
+	Status      string
+	Username    string
+}
+
+func UseSFDXSession(authData SFDXAuth) {
+	creds := ForceSession{
+		AccessToken:   authData.AccessToken,
+		InstanceUrl:   authData.InstanceUrl,
+		ForceEndpoint: EndpointCustom,
+		UserInfo: &UserInfo{
+			OrgId: authData.Id,
+		},
+		SessionOptions: &SessionOptions{
+			ApiVersion:    ApiVersionNumber(),
+			RefreshMethod: RefreshSFDX,
+			Alias:         authData.Alias,
+		},
+	}
+	ForceSaveLogin(creds, os.Stderr)
+}
+
+func GetSFDXAuth(user string) (auth SFDXAuth, err error) {
+	fmt.Println("Getting SFDX AUTH FOR " + user)
+	cmd := exec.Command("sfdx", "force:org:display", "-u"+user, "--json")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	err = cmd.Start()
+	if err != nil {
+		return
+	}
+
+	type authData struct {
+		Result SFDXAuth
+	}
+	var aData authData
+	if err := json.NewDecoder(stdout).Decode(&aData); err != nil {
+		ErrorAndExit(err.Error())
+	}
+	if err := cmd.Wait(); err != nil {
+		ErrorAndExit(err.Error())
+	}
+	auth = aData.Result
+	return
+}

--- a/lib/soap.go
+++ b/lib/soap.go
@@ -154,8 +154,18 @@ func (s *Soap) Execute(action, query string) (response []byte, err error) {
 	if err != nil {
 		return
 	}
+	if isSoapInvalidSessionError(response) {
+		err = SessionExpiredError
+		return
+	}
 	err = processError(response)
 	return
+}
+
+func isSoapInvalidSessionError(body []byte) bool {
+	var soapError SoapError
+	xml.Unmarshal(body, &soapError)
+	return soapError.FaultCode == "sf:INVALID_SESSION_ID"
 }
 
 func processError(body []byte) (err error) {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	//"fmt"
 
 	"github.com/heroku/force/command"
 	. "github.com/heroku/force/error"
@@ -23,11 +22,10 @@ func main() {
 			if err := cmd.Flag.Parse(args[1:]); err != nil {
 				os.Exit(2)
 			}
-			creds, err := ActiveCredentials(false)
+			_, err := ActiveCredentials(false)
 			if err != nil {
 				ErrorAndExit(err.Error())
 			}
-			SetApiVersion(creds.ApiVersion)
 
 			cmd.Run(cmd, cmd.Flag.Args())
 			return


### PR DESCRIPTION
_I started working on fixing session refresh for SOAP calls and for sfdx sessions, and ended up going down a rabbit hole.  This starts to tease apart the session-related state (session id and instance url) from the information about the current user (user id, org id, etc.) and local options tied to a session (api version and authentication method)._

Refresh the session after a SOAP call fails due to an expired session.

Add support for refreshing sfdx sessions.

Move data about the current user (UserName, UserId, ProfileId, OrgId,
and OrgNamespace) into a new UserInfo struct instead of storing it
directly in the ForceCredentials.

Move stored options about the session (API version, user account alias,
and session refresh method) into new SessionOptions struct.

Rename ForceCredentials struct to ForceSession since it contains more
than credentials.

Remove unnecessary calls to get the SOAP endpoint since it can be
constructed from the InstanceUrl and API Version.