### PR TITLE
Fetch All Logs

### DIFF
--- a/command/log.go
+++ b/command/log.go
@@ -34,7 +34,7 @@ func getLog(cmd *Command, args []string) {
 		if err != nil {
 			ErrorAndExit(err.Error())
 		}
-		DisplayForceRecords(records)
+		force.DisplayAllForceRecords(records)
 	} else if args[0] == "delete" {
 		if len(args) != 2 {
 			ErrorAndExit("You need to provide the id of a debug log to delete.")

--- a/lib/display.go
+++ b/lib/display.go
@@ -182,6 +182,21 @@ func DisplayForceRecordsf(records []ForceRecord, format string) {
 	}
 }
 
+func (f *Force) DisplayAllForceRecords(result ForceQueryResult) {
+	currentResult := result
+	var err error
+	for {
+		DisplayForceRecords(currentResult)
+		if currentResult.Done {
+			return
+		}
+		currentResult, err = f.getForceResult(currentResult.NextRecordsUrl)
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+	}
+}
+
 func DisplayForceRecords(result ForceQueryResult) {
 	if len(result.Records) > 0 {
 		fmt.Print(RenderForceRecords(result.Records))

--- a/lib/force.go
+++ b/lib/force.go
@@ -1356,6 +1356,15 @@ func (f *Force) PatchREST(url string, content string) (result string, err error)
 	return
 }
 
+func (f *Force) getForceResult(url string) (results ForceQueryResult, err error) {
+	body, err := f.httpGet(fmt.Sprintf("%s%s", f.Credentials.InstanceUrl, url))
+	if err != nil {
+		return
+	}
+	json.Unmarshal(body, &results)
+	return
+}
+
 func (f *Force) httpGet(url string) (body []byte, err error) {
 	body, err = f.httpGetRequest(url, "Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
 	if err == SessionExpiredError {


### PR DESCRIPTION
Add DisplayAllForceRecords function to display the records in the result
set, then fetch additional records if the result set is not complete.

Update `force log` to fetch all logs.