### PR TITLE
Fix rest Command

### DIFF
--- a/command/rest.go
+++ b/command/rest.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	. "github.com/heroku/force/error"
@@ -18,46 +19,61 @@ Execute a REST request
 
 Examples:
 
-  force rest get "tooling/query?q=Select id From Account"
+  force rest get "/tooling/query?q=Select id From Account"
 
-  force rest get appMenu/AppSwitcher
+  force rest get /appMenu/AppSwitcher
 
-  force rest post "tooling/sobjects/CustomField/00D9A0000000TgcUAE" path/to/definition.json
-  
+  force rest post "/tooling/sobjects/CustomField/00D9A0000000TgcUAE" path/to/definition.json
+
 `,
 }
 
 func runRest(cmd *Command, args []string) {
+	var (
+		data = ""
+		msg  = ""
+		err  error
+	)
 	force, _ := ActiveForce()
-	if len(args) != 3 {
+	if len(args) == 0 {
 		cmd.PrintUsage()
-	} else {
-		// TODO parse args looking for get, post etc
-		// and handle other than get
-		var (
-			data = ""
-			msg  = ""
-		)
-		var err error
-		if strings.ToLower(args[0]) == "get" {
-			data, err = force.GetREST(args[1])
-			if err != nil {
-				ErrorAndExit(err.Error())
-			}
-			msg = strings.Replace(data, "null", "\"null\"", -1)
-		} else if strings.ToLower(args[0]) == "post" ||
-			strings.ToLower(args[0]) == "patch" {
-			url := args[1]
-			datafile, err := ioutil.ReadFile(args[2])
-			data, err = force.PostPatchREST(url, string(datafile), strings.ToUpper(args[0]))
-			if err != nil {
-				ErrorAndExit(err.Error())
-			}
-			data = string(data)
-			data = strings.Replace(data, "null", "\"null\"", -1)
-			msg = fmt.Sprintf("%s %s\n%s", strings.ToUpper(args[0]), url, data)
+	} else if strings.ToLower(args[0]) == "get" {
+		url := "/"
+		if len(args) > 1 {
+			url = args[1]
 		}
+		data, err = force.GetREST(url)
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+		msg = strings.Replace(data, "null", "\"null\"", -1)
 		fmt.Println(msg)
-
+	} else if strings.ToLower(args[0]) == "post" || strings.ToLower(args[0]) == "patch" {
+		if len(args) < 2 {
+			cmd.PrintUsage()
+			os.Exit(1)
+		}
+		url := args[1]
+		var input []byte
+		if len(args) > 2 {
+			input, err = ioutil.ReadFile(args[2])
+		} else {
+			input, err = ioutil.ReadAll(os.Stdin)
+		}
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+		data, err = force.PostPatchREST(url, string(input), strings.ToUpper(args[0]))
+		if err != nil {
+			ErrorAndExit(err.Error())
+		}
+		data = string(data)
+		data = strings.Replace(data, "null", "\"null\"", -1)
+		msg = fmt.Sprintf("%s %s\n%s", strings.ToUpper(args[0]), url, data)
+		fmt.Println(msg)
+	} else {
+		cmd.PrintUsage()
+		os.Exit(1)
 	}
+
 }

--- a/lib/force.go
+++ b/lib/force.go
@@ -1316,8 +1316,12 @@ func (f *Force) Whoami() (me ForceRecord, err error) {
 	return
 }
 
+func (f *Force) fullRestUrl(url string) string {
+	return fmt.Sprintf("%s/services/data/%s/%s", f.Credentials.InstanceUrl, apiVersion, strings.TrimLeft(url, "/"))
+}
+
 func (f *Force) GetREST(url string) (result string, err error) {
-	fullUrl := fmt.Sprintf("%s/services/data/%s/%s", f.Credentials.InstanceUrl, apiVersion, url)
+	fullUrl := f.fullRestUrl(url)
 	body, err := f.httpGetRequest(fullUrl, "Authorization", fmt.Sprintf("Bearer %s", f.Credentials.AccessToken))
 	if err == SessionExpiredError {
 		f.RefreshSessionOrExit()
@@ -1336,7 +1340,7 @@ func (f *Force) PostPatchREST(url string, content string, method string) (result
 }
 
 func (f *Force) PostREST(url string, content string) (result string, err error) {
-	fullUrl := fmt.Sprintf("%s/services/data/%s/%s", f.Credentials.InstanceUrl, apiVersion, url)
+	fullUrl := f.fullRestUrl(url)
 	body, err := f.httpPostJSON(fullUrl, content)
 	if err == SessionExpiredError {
 		f.RefreshSessionOrExit()
@@ -1347,7 +1351,7 @@ func (f *Force) PostREST(url string, content string) (result string, err error) 
 }
 
 func (f *Force) PatchREST(url string, content string) (result string, err error) {
-	fullUrl := fmt.Sprintf("%s/services/data/%s/%s", f.Credentials.InstanceUrl, apiVersion, url)
+	fullUrl := f.fullRestUrl(url)
 	body, err := f.httpPatchJSON(fullUrl, content)
 	if err == SessionExpiredError {
 		f.RefreshSessionOrExit()


### PR DESCRIPTION
Fix parsing of arguments `force rest` arguments.

Allow leading slash on REST URLs.

Allow patch and post to read input from stdin.