### PR TITLE
Report CSV Parse Errors

### DIFF
--- a/command/bulk.go
+++ b/command/bulk.go
@@ -494,10 +494,12 @@ func createBulkUpsertJob(csvFilePath string, objectType string, format string, e
 }
 
 func addBatchToJob(csvFilePath string, jobId string) (result BatchInfo, err error) {
-
 	force, _ := ActiveForce()
 
-	batches := SplitCSV(csvFilePath, 10000)
+	batches, err := SplitCSV(csvFilePath, 10000)
+	if err != nil {
+		return
+	}
 	for b := range batches {
 		result, err = force.AddBatchToJob(batches[b], jobId)
 		if err != nil {
@@ -509,7 +511,7 @@ func addBatchToJob(csvFilePath string, jobId string) (result BatchInfo, err erro
 	return
 }
 
-func SplitCSV(csvFilePath string, batchsize int) (batches []string) {
+func SplitCSV(csvFilePath string, batchsize int) (batches []string, err error) {
 	f, err := os.Open(csvFilePath)
 	if err != nil {
 		return
@@ -520,7 +522,8 @@ func SplitCSV(csvFilePath string, batchsize int) (batches []string) {
 		return
 	}
 
-	return splitFileIntoBatches(filedata, batchsize)
+	batches = splitFileIntoBatches(filedata, batchsize)
+	return
 }
 
 func splitFileIntoBatches(rows [][]string, batchsize int) (batches []string) {

--- a/command/bulk_test.go
+++ b/command/bulk_test.go
@@ -32,7 +32,8 @@ var _ = Describe("Bulk", func() {
 value"`
 			ioutil.WriteFile(csvFilePath, []byte(csvContents), 0644)
 
-			batches := SplitCSV(csvFilePath, 2)
+			batches, err := SplitCSV(csvFilePath, 2)
+			Expect(err).To(BeNil())
 
 			Expect(len(batches)).To(Equal(2))
 			Expect(batches[0]).To(HavePrefix("Id,Description"))
@@ -47,11 +48,29 @@ value"`
 001000000000000000,single value`
 			ioutil.WriteFile(csvFilePath, []byte(csvContents), 0644)
 
-			batches := SplitCSV(csvFilePath, 2)
+			batches, err := SplitCSV(csvFilePath, 2)
+			Expect(err).To(BeNil())
 
 			Expect(len(batches)).To(Equal(1))
 			Expect(batches[0]).To(HavePrefix("Id,Description"))
 			Expect(batches[0]).To(HaveSuffix("single value\n"))
+		})
+
+		It("should return an error for an invalid file", func() {
+			csvFilePath := tempDir + "/bulk.csv"
+			csvContents := `Column 1
+001000000000000000,single value`
+			ioutil.WriteFile(csvFilePath, []byte(csvContents), 0644)
+
+			_, err := SplitCSV(csvFilePath, 2)
+			Expect(err).To(MatchError(MatchRegexp("wrong number of fields")))
+		})
+
+		It("should return an error for a missing file", func() {
+			csvFilePath := tempDir + "/no-such-file.csv"
+
+			_, err := SplitCSV(csvFilePath, 2)
+			Expect(err).To(MatchError(MatchRegexp("no such file or directory")))
 		})
 	})
 })


### PR DESCRIPTION
Exit with an error when the CSV input for `force bulk` cannot be parsed.