### PR TITLE
Add QueryOptions Argument to Force.Query

### DIFF
--- a/command/export.go
+++ b/command/export.go
@@ -35,7 +35,7 @@ func getMetadataType(metadataType string, folders map[string]string) (member []s
 	} else {
 		queryString = "SELECT Id, DeveloperName, Folder.DeveloperName, Folder.NamespacePrefix, NamespacePrefix FROM " + metadataType
 	}
-	queryResult, err := force.Query(fmt.Sprintf("%s", queryString), false)
+	queryResult, err := force.Query(fmt.Sprintf("%s", queryString), QueryOptions{IsTooling: false})
 	if err != nil {
 		ErrorAndExit(err.Error())
 	}
@@ -179,7 +179,7 @@ func runExport(cmd *Command, args []string) {
 		{Name: []string{"Workflow"}, Members: []string{"*"}},
 	}
 
-	folderResult, err := force.Query(fmt.Sprintf("%s", "SELECT Id, Type, NamespacePrefix, DeveloperName from Folder Where Type in ('Dashboard', 'Document', 'Email', 'Report')"), false)
+	folderResult, err := force.Query(fmt.Sprintf("%s", "SELECT Id, Type, NamespacePrefix, DeveloperName from Folder Where Type in ('Dashboard', 'Document', 'Email', 'Report')"), QueryOptions{IsTooling: false})
 	folders := make(map[string]map[string]string)
 	for _, folder := range folderResult.Records {
 		if folder["DeveloperName"] != nil {

--- a/command/password.go
+++ b/command/password.go
@@ -50,7 +50,7 @@ func runPasswordStatus(args []string) {
 		ErrorAndExit("must specify user name")
 	}
 	force, _ := ActiveForce()
-	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), false)
+	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), QueryOptions{IsTooling: false})
 	if err != nil {
 		ErrorAndExit(err.Error())
 	} else {
@@ -68,7 +68,7 @@ func runPasswordReset(args []string) {
 		ErrorAndExit("must specify user name")
 	}
 	force, _ := ActiveForce()
-	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), false)
+	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), QueryOptions{IsTooling: false})
 	object, err := force.ResetPassword(records.Records[0]["Id"].(string))
 	if err != nil {
 		ErrorAndExit(err.Error())
@@ -82,7 +82,7 @@ func runPasswordChange(args []string) {
 		ErrorAndExit("must specify user name")
 	}
 	force, _ := ActiveForce()
-	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), false)
+	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), QueryOptions{IsTooling: false})
 	if err != nil {
 		ErrorAndExit(err.Error())
 	} else {

--- a/command/query.go
+++ b/command/query.go
@@ -54,7 +54,7 @@ func runQuery(cmd *Command, args []string) {
 
 		soql := strings.Join(args, " ")
 
-		records, err := force.Query(fmt.Sprintf("%s", soql), isTooling)
+		records, err := force.Query(fmt.Sprintf("%s", soql), QueryOptions{isTooling})
 
 		if err != nil {
 			ErrorAndExit(err.Error())

--- a/lib/force.go
+++ b/lib/force.go
@@ -156,6 +156,10 @@ type Result struct {
 	Message string
 }
 
+type QueryOptions struct {
+	IsTooling bool
+}
+
 type BatchResult struct {
 	Results []Result
 }
@@ -625,9 +629,9 @@ func (f *Force) GetSobject(name string) (sobject ForceSobject, err error) {
 	return
 }
 
-func (f *Force) Query(query string, isTooling bool) (result ForceQueryResult, err error) {
+func (f *Force) Query(query string, options QueryOptions) (result ForceQueryResult, err error) {
 	toolingPath := ""
-	if isTooling {
+	if options.IsTooling {
 		toolingPath = "tooling/"
 	}
 


### PR DESCRIPTION
Replace boolean isTooling argument to Force.Query with a new
QueryOptions struct argument to make calling code easier to read.