### PR TITLE
Make Query Options Optional

### DIFF
--- a/command/password.go
+++ b/command/password.go
@@ -50,7 +50,7 @@ func runPasswordStatus(args []string) {
 		ErrorAndExit("must specify user name")
 	}
 	force, _ := ActiveForce()
-	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), QueryOptions{IsTooling: false})
+	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]))
 	if err != nil {
 		ErrorAndExit(err.Error())
 	} else {
@@ -68,7 +68,7 @@ func runPasswordReset(args []string) {
 		ErrorAndExit("must specify user name")
 	}
 	force, _ := ActiveForce()
-	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), QueryOptions{IsTooling: false})
+	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]))
 	object, err := force.ResetPassword(records.Records[0]["Id"].(string))
 	if err != nil {
 		ErrorAndExit(err.Error())
@@ -82,7 +82,7 @@ func runPasswordChange(args []string) {
 		ErrorAndExit("must specify user name")
 	}
 	force, _ := ActiveForce()
-	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]), QueryOptions{IsTooling: false})
+	records, err := force.Query(fmt.Sprintf("select Id From User Where UserName = '%s'", args[0]))
 	if err != nil {
 		ErrorAndExit(err.Error())
 	} else {

--- a/command/query.go
+++ b/command/query.go
@@ -37,14 +37,17 @@ func runQuery(cmd *Command, args []string) {
 			format = "csv"
 		}
 		var formatArg = ""
-		var isTooling = false
 		var formatIndex = 1
+		var queryOptions []func(*QueryOptions)
 		if len(args) == 2 {
 			formatArg = args[len(args)-formatIndex]
 		} else if len(args) == 3 {
 			formatIndex = 2
 			formatArg = args[len(args)-formatIndex]
-			isTooling = true
+			tooling := func(options *QueryOptions) {
+				options.IsTooling = true
+			}
+			queryOptions = append(queryOptions, tooling)
 		}
 
 		if strings.Contains(formatArg, "format:") {
@@ -54,7 +57,7 @@ func runQuery(cmd *Command, args []string) {
 
 		soql := strings.Join(args, " ")
 
-		records, err := force.Query(fmt.Sprintf("%s", soql), QueryOptions{isTooling})
+		records, err := force.Query(fmt.Sprintf("%s", soql), queryOptions...)
 
 		if err != nil {
 			ErrorAndExit(err.Error())

--- a/lib/folder.go
+++ b/lib/folder.go
@@ -13,7 +13,7 @@ type Folders map[FolderId]FolderName
 type FolderedMetadata map[FolderType]Folders
 
 func (force *Force) GetAllFolders() (folders FolderedMetadata, err error) {
-	folderResult, err := force.Query(fmt.Sprintf("%s", "SELECT Id, Type, NamespacePrefix, DeveloperName from Folder Where Type in ('Dashboard', 'Document', 'Email', 'Report')"), QueryOptions{IsTooling: false})
+	folderResult, err := force.Query(fmt.Sprintf("%s", "SELECT Id, Type, NamespacePrefix, DeveloperName from Folder Where Type in ('Dashboard', 'Document', 'Email', 'Report')"))
 	if err != nil {
 		return
 	}
@@ -43,7 +43,7 @@ func (force *Force) GetMetadataInFolders(metadataType FolderType, folders Folder
 	} else {
 		queryString = "SELECT Id, DeveloperName, Folder.DeveloperName, Folder.NamespacePrefix, NamespacePrefix FROM " + string(metadataType)
 	}
-	queryResult, err := force.Query(fmt.Sprintf("%s", queryString), QueryOptions{IsTooling: false})
+	queryResult, err := force.Query(fmt.Sprintf("%s", queryString))
 	if err != nil {
 		return
 	}

--- a/lib/force.go
+++ b/lib/force.go
@@ -629,9 +629,13 @@ func (f *Force) GetSobject(name string) (sobject ForceSobject, err error) {
 	return
 }
 
-func (f *Force) Query(query string, options QueryOptions) (result ForceQueryResult, err error) {
+func (f *Force) Query(query string, options ...func(*QueryOptions)) (result ForceQueryResult, err error) {
+	queryOptions := QueryOptions{}
+	for _, option := range options {
+		option(&queryOptions)
+	}
 	toolingPath := ""
-	if options.IsTooling {
+	if queryOptions.IsTooling {
 		toolingPath = "tooling/"
 	}
 


### PR DESCRIPTION
Update Query function to make options argument optional using the
functional options pattern[1], in which the options are passed as a
variadic parameter of functions that update the options.  No options
need to be passed to use the defaults.

  1. https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis